### PR TITLE
Fix remaining Flake8 and ESLint errors

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,7 +1,7 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
-from backend.config import config # Moved import to top
+from backend.config import config  # Moved import to top
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -49,7 +49,8 @@ def create_project():
     name = data["name"].strip()
     description = data.get("description", "").strip()
 
-    project = Project(name=name, description=description, user_id=current_user_id)
+    project = Project(name=name, description=description,
+                      user_id=current_user_id)
     db.session.add(project)
     db.session.commit()
 
@@ -278,7 +279,10 @@ def create_task(stage_id):
     user = User.query.get(current_user_id)
     record_activity(
         action_type="TASK_CREATED",
-        description=f"User '{user.username}' created task '{task.content[:30]}...' in stage '{stage.name}'",
+        description=(
+            f"User '{user.username}' created task '{task.content[:30]}...' "
+            f"in stage '{stage.name}'"
+        ),
         user_id=current_user_id,
         project_id=stage.project_id,
         task_id=task.id,
@@ -381,7 +385,10 @@ def update_task(task_id):
         user = User.query.get(current_user_id)
         record_activity(
             action_type="TASK_UPDATED",
-            description=f"User '{user.username}' updated task '{task.content[:30]}...'",
+            description=(
+                f"User '{user.username}' updated task "
+                f"'{task.content[:30]}...'"
+            ),
             user_id=current_user_id,
             project_id=task.stage.project.id,
             task_id=task.id,
@@ -437,7 +444,8 @@ def create_subtask(task_id):
 
     if not isinstance(completed, bool):
         return (
-            jsonify({"message": "Invalid format for completed flag, must be boolean."}),
+            jsonify(
+                {"message": "Invalid format for completed flag, must be boolean."}),
             400,
         )
 
@@ -544,14 +552,18 @@ def create_comment(task_id):
 
     content = data["content"].strip()
 
-    comment = Comment(content=content, task_id=task.id, user_id=current_user_id)
+    comment = Comment(content=content, task_id=task.id,
+                      user_id=current_user_id)
     db.session.add(comment)
     db.session.commit()
 
     user = User.query.get(current_user_id)
     record_activity(
         action_type="COMMENT_ADDED",
-        description=f"User '{user.username}' commented on task '{task.content[:30]}...'",
+        description=(
+            f"User '{user.username}' commented on task "
+            f"'{task.content[:30]}...'"
+        ),
         user_id=current_user_id,
         project_id=task.stage.project.id,
         task_id=task.id,
@@ -637,7 +649,8 @@ def create_tag():
         return jsonify({"message": "Tag name is required"}), 400
 
     name = data["name"].strip()
-    existing_tag = Tag.query.filter(db.func.lower(Tag.name) == name.lower()).first()
+    existing_tag = Tag.query.filter(
+        db.func.lower(Tag.name) == name.lower()).first()
 
     if existing_tag:
         return jsonify(existing_tag.to_dict()), 200
@@ -650,13 +663,15 @@ def create_tag():
         IntegrityError
     ):  # Handles potential race conditions if another request creates the same tag
         db.session.rollback()
-        existing_tag = Tag.query.filter(db.func.lower(Tag.name) == name.lower()).first()
+        existing_tag = Tag.query.filter(
+            db.func.lower(Tag.name) == name.lower()).first()
         if existing_tag:
             return jsonify(existing_tag.to_dict()), 200
         else:
             # This case should ideally not be reached if the first check was done correctly
             return (
-                jsonify({"message": "Error creating tag, possibly due to a conflict."}),
+                jsonify(
+                    {"message": "Error creating tag, possibly due to a conflict."}),
                 500,
             )
 
@@ -724,7 +739,10 @@ def add_tag_to_task(task_id):
     user = User.query.get(current_user_id)
     record_activity(
         action_type="TAG_ADDED_TO_TASK",
-        description=f"User '{user.username}' added tag '{tag_to_add.name}' to task '{task.content[:30]}...'",
+        description=(
+            f"User '{user.username}' added tag '{tag_to_add.name}' "
+            f"to task '{task.content[:30]}...'"
+        ),
         user_id=current_user_id,
         project_id=task.stage.project.id,
         task_id=task.id,
@@ -759,7 +777,10 @@ def remove_tag_from_task(task_id, tag_id):
     user = User.query.get(current_user_id)
     record_activity(
         action_type="TAG_REMOVED_FROM_TASK",
-        description=f"User '{user.username}' removed tag '{tag_to_remove.name}' from task '{task.content[:30]}...'",
+        description=(
+            f"User '{user.username}' removed tag '{tag_to_remove.name}' "
+            f"from task '{task.content[:30]}...'"
+        ),
         user_id=current_user_id,
         project_id=task.stage.project.id,
         task_id=task.id,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -13,7 +13,8 @@ class User(db.Model):
     )
     projects = db.relationship("Project", backref="author", lazy="dynamic")
     comments = db.relationship("Comment", backref="commenter", lazy="dynamic")
-    activity_logs = db.relationship("ActivityLog", backref="user", lazy="dynamic")
+    activity_logs = db.relationship(
+        "ActivityLog", backref="user", lazy="dynamic")
 
     def set_password(self, password):
         from werkzeug.security import generate_password_hash
@@ -76,7 +77,8 @@ class Project(db.Model):
 class Stage(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
-    project_id = db.Column(db.Integer, db.ForeignKey("project.id"), nullable=False)
+    project_id = db.Column(db.Integer, db.ForeignKey(
+        "project.id"), nullable=False)
     order = db.Column(db.Integer, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(
@@ -150,8 +152,9 @@ class Task(db.Model):
             "tags": [tag.to_dict() for tag in self.tags] if include_tags else [],
         }
         if include_subtasks:
+            subtasks_query = self.subtasks.order_by(SubTask.order).all()
             data["subtasks"] = [
-                subtask.to_dict() for subtask in self.subtasks.order_by(SubTask.order).all()
+                subtask.to_dict() for subtask in subtasks_query
             ]
         return data
 
@@ -170,7 +173,8 @@ class Tag(db.Model):
 # Association table for Task and Tag many-to-many relationship
 task_tag = db.Table(
     "task_tag",
-    db.Column("task_id", db.Integer, db.ForeignKey("task.id"), primary_key=True),
+    db.Column("task_id", db.Integer, db.ForeignKey(
+        "task.id"), primary_key=True),
     db.Column("tag_id", db.Integer, db.ForeignKey("tag.id"), primary_key=True),
 )
 
@@ -184,7 +188,8 @@ class ActivityLog(db.Model):
         db.Text, nullable=False
     )  # e.g., "User 'X' created task 'Y'"
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    project_id = db.Column(db.Integer, db.ForeignKey("project.id"), nullable=True)
+    project_id = db.Column(
+        db.Integer, db.ForeignKey("project.id"), nullable=True)
     task_id = db.Column(db.Integer, db.ForeignKey("task.id"), nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -240,7 +245,8 @@ class Comment(db.Model):
 class SubTask(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.Text, nullable=False)
-    parent_task_id = db.Column(db.Integer, db.ForeignKey("task.id"), nullable=False)
+    parent_task_id = db.Column(
+        db.Integer, db.ForeignKey("task.id"), nullable=False)
     completed = db.Column(db.Boolean, default=False)
     order = db.Column(db.Integer, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/backend/config.py
+++ b/backend/config.py
@@ -22,7 +22,8 @@ class TestingConfig(Config):
     SQLALCHEMY_DATABASE_URI = (
         os.environ.get("TEST_DATABASE_URL") or "sqlite:///:memory:"
     )
-    WTF_CSRF_ENABLED = False  # Disable CSRF for testing forms if any; not strictly needed for API tests
+    # Disable CSRF for testing forms if any; not strictly needed for API tests
+    WTF_CSRF_ENABLED = False
 
 
 class ProductionConfig(Config):

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -63,7 +63,8 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, target_metadata=get_metadata(), literal_binds=True)
+    context.configure(url=url, target_metadata=get_metadata(),
+                      literal_binds=True)
 
     with context.begin_transaction():
         context.run_migrations()

--- a/backend/tests/test_activity_log_api.py
+++ b/backend/tests/test_activity_log_api.py
@@ -44,38 +44,38 @@ def test_get_project_activities_success(
 
     # Find PROJECT_CREATED activity
     project_created_activity = next(
-        (act for act in activities if act["action_type"] == "PROJECT_CREATED"), None
+        (act for act in activities if act["action_type"]
+         == "PROJECT_CREATED"), None
     )
     assert project_created_activity is not None
-    assert (
-        f"User '{username}' created project '{project_name}'"
-        in project_created_activity["description"]
-    )
+    desc_str = f"User '{username}' created project '{project_name}'"
+    assert desc_str in project_created_activity["description"]
     assert project_created_activity["user_username"] == username
     assert project_created_activity["project_id"] == project_id
 
     # Find TASK_CREATED activity
     task_created_activity = next(
-        (act for act in activities if act["action_type"] == "TASK_CREATED"), None
+        (act for act in activities if act["action_type"]
+         == "TASK_CREATED"), None
     )
     assert task_created_activity is not None
-    assert (
-        f"User '{username}' created task '{task_content_ellipsis}' in stage '{stage_name}'"
-        in task_created_activity["description"]
+    desc_str = (
+        f"User '{username}' created task '{task_content_ellipsis}' "
+        f"in stage '{stage_name}'"
     )
+    assert desc_str in task_created_activity["description"]
     assert task_created_activity["user_username"] == username
     assert task_created_activity["project_id"] == project_id
     assert task_created_activity["task_id"] == task_id
 
     # Find COMMENT_ADDED activity
     comment_added_activity = next(
-        (act for act in activities if act["action_type"] == "COMMENT_ADDED"), None
+        (act for act in activities if act["action_type"]
+         == "COMMENT_ADDED"), None
     )
     assert comment_added_activity is not None
-    assert (
-        f"User '{username}' commented on task '{task_content_ellipsis}'"
-        in comment_added_activity["description"]
-    )
+    desc_str = f"User '{username}' commented on task '{task_content_ellipsis}'"
+    assert desc_str in comment_added_activity["description"]
     assert comment_added_activity["user_username"] == username
     assert comment_added_activity["project_id"] == project_id
     assert comment_added_activity["task_id"] == task_id
@@ -113,42 +113,45 @@ def test_get_task_activities_success(
     assert response.status_code == 200
     activities = response.json
     assert isinstance(activities, list)
-    assert (
-        len(activities) >= 3
-    )  # Task Created, Comment Added, Task Updated (could be more if fixture logs stage creation etc.)
+    # Task Created, Comment Added, Task Updated
+    # (could be more if fixture logs stage creation etc.)
+    assert len(activities) >= 3
 
     # TASK_UPDATED should be the most recent
     task_updated_activity = next(
-        (act for act in activities if act["action_type"] == "TASK_UPDATED"), None
+        (act for act in activities if act["action_type"]
+         == "TASK_UPDATED"), None
     )
     assert task_updated_activity is not None
-    assert (
+    desc_str = (
         f"User '{username}' updated task '{updated_task_content[:30]}...'"
-        in task_updated_activity["description"]
     )
+    assert desc_str in task_updated_activity["description"]
     assert task_updated_activity["user_username"] == username
     assert task_updated_activity["task_id"] == task_id
     assert task_updated_activity["project_id"] == project_id
 
     # COMMENT_ADDED
     comment_added_activity = next(
-        (act for act in activities if act["action_type"] == "COMMENT_ADDED"), None
+        (act for act in activities if act["action_type"]
+         == "COMMENT_ADDED"), None
     )
     assert comment_added_activity is not None
     # Note: The description for comment activity uses the task content *at the time of commenting*.
     # If the task was updated after the comment, the description reflects the older task content.
     # Here, task_content_ellipsis is the original content. The update happened *after* the comment.
-    assert (
+    desc_str = (
         f"User '{username}' commented on task '{task_content_ellipsis}'"
-        in comment_added_activity["description"]
     )
+    assert desc_str in comment_added_activity["description"]
     assert comment_added_activity["user_username"] == username
     assert comment_added_activity["task_id"] == task_id
     assert comment_added_activity["project_id"] == project_id
 
     # TASK_CREATED
     task_created_activity = next(
-        (act for act in activities if act["action_type"] == "TASK_CREATED"), None
+        (act for act in activities if act["action_type"]
+         == "TASK_CREATED"), None
     )
     assert task_created_activity is not None
     assert task_created_activity["user_username"] == username
@@ -167,7 +170,8 @@ def test_get_activities_non_existent_project(test_client, auth_headers):
 
 def test_get_activities_non_existent_task(test_client, auth_headers):
     request_headers = {"Authorization": auth_headers["Authorization"]}
-    response = test_client.get("/api/tasks/99998/activities", headers=request_headers)
+    response = test_client.get(
+        "/api/tasks/99998/activities", headers=request_headers)
     assert response.status_code == 404
     assert response.json["message"] == "Task not found"
 
@@ -176,7 +180,8 @@ def test_get_activities_unauthorized_no_token(test_client, created_task_data):
     project_id = created_task_data["project_id"]
     task_id = created_task_data["task_id"]
 
-    response_project = test_client.get(f"/api/projects/{project_id}/activities")
+    response_project = test_client.get(
+        f"/api/projects/{project_id}/activities")
     assert response_project.status_code == 401
 
     response_task = test_client.get(f"/api/tasks/{task_id}/activities")
@@ -292,7 +297,9 @@ def test_task_deletion_logs_activity(
             delete_activity_found = True
             assert f"User '{username}' deleted task" in activity["description"]
             break
-    assert delete_activity_found, "TASK_DELETED activity not found for deleted task"
+    assert delete_activity_found, (
+        "TASK_DELETED activity not found for deleted task"
+    )
 
     # Task activities endpoint for the deleted task should ideally be 404 or return specific logs
     # For now, we'll assume the task is gone, so its specific activity log might not be the primary check point after deletion

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -100,7 +100,8 @@ def test_login_incorrect_password(test_client, db_session):
 
 
 def test_login_missing_fields(test_client):
-    response = login_user(test_client, "someuser@example.com", "")  # Missing password
+    response = login_user(
+        test_client, "someuser@example.com", "")  # Missing password
     assert response.status_code == 400
     assert response.json["message"] == "Missing email or password"
 
@@ -157,7 +158,8 @@ def test_logout(test_client, db_session):
     access_token = login_response.json["access_token"]
 
     headers = {"Authorization": f"Bearer {access_token}"}
-    response = test_client.post("/api/auth/logout", headers=headers)  # POST for logout
+    response = test_client.post(
+        "/api/auth/logout", headers=headers)  # POST for logout
     assert response.status_code == 200
     assert (
         response.json["message"]

--- a/backend/tests/test_comments_api.py
+++ b/backend/tests/test_comments_api.py
@@ -218,15 +218,14 @@ def test_create_comment_activity_log(
             and activity["project_id"] == project_id
             and activity["user_id"] == auth_headers["user_id"]
         ):
-            assert (
-                f"commented on task '{task_content_ellipsis}'"
-                in activity["description"]
-            )
+            desc_str = f"commented on task '{task_content_ellipsis}'"
+            assert desc_str in activity["description"]
             comment_activity_found = True
             break
-    assert (
-        comment_activity_found
-    ), "COMMENT_ADDED activity not found for new comment in project activities"
+    assert comment_activity_found, (
+        "COMMENT_ADDED activity not found for new comment in project "
+        "activities"
+    )
 
     # Check activity log for the task
     task_activity_response = test_client.get(
@@ -241,12 +240,11 @@ def test_create_comment_activity_log(
             activity["action_type"] == "COMMENT_ADDED"
             and activity["user_id"] == auth_headers["user_id"]
         ):
-            assert (
-                f"commented on task '{task_content_ellipsis}'"
-                in activity["description"]
-            )
+            desc_str = f"commented on task '{task_content_ellipsis}'"
+            assert desc_str in activity["description"]
             task_comment_activity_found = True
             break
-    assert (
-        task_comment_activity_found
-    ), "COMMENT_ADDED activity not found for new comment on task activities"
+    assert task_comment_activity_found, (
+        "COMMENT_ADDED activity not found for new comment on task "
+        "activities"
+    )

--- a/frontend/src/pages/__tests__/ProjectViewPage.test.jsx
+++ b/frontend/src/pages/__tests__/ProjectViewPage.test.jsx
@@ -190,7 +190,7 @@ describe('ProjectViewPage', () => {
     const addTaskButton = screen.getByRole('button', { name: 'Add Task to To Do' });
     await userEvent.click(addTaskButton);
     
-    const taskModal = await screen.findByTestId('task-modal');
+    await screen.findByTestId('task-modal'); // Ensure modal is present
     const saveButtonInModal = screen.getByRole('button', { name: 'SaveModalTask' }); // From mock
     await userEvent.click(saveButtonInModal);
     
@@ -233,7 +233,7 @@ describe('ProjectViewPage', () => {
     const taskElement = screen.getByTestId('task-1');
     await userEvent.click(taskElement);
     
-    const taskModal = await screen.findByTestId('task-modal');
+    await screen.findByTestId('task-modal'); // Ensure modal is present
     const triggerUpdateInModalButton = screen.getByRole('button', { name: 'TriggerTaskUpdateInModal' });
     await userEvent.click(triggerUpdateInModalButton);
 

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+/* globals expect, test, describe, it, vi, beforeAll, beforeEach, afterAll, afterEach */
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)


### PR DESCRIPTION
This commit addresses the outstanding CI issues:

**Backend (Flake8 Fixes):**
- I fixed `F821 undefined name 'Task'` in `tests/test_tags_api.py` by adding the missing model import.
- I attempted automated line length formatting for `E501` errors using `autopep8`.
- I manually refactored numerous `E501` (line too long) errors across various backend files, including in `app/`, `tests/`, and `config.py`, by shortening lines, reformatting comments, and breaking long expressions.
- I fixed `E261` (spacing before inline comment) in `app/__init__.py`.

**Frontend (ESLint Fixes):**
- I resolved `no-undef` errors for test globals (`beforeAll`, `afterEach`, `afterAll`, etc.) in `frontend/src/setupTests.js` by adding an explicit `/* globals ... */` comment.
- I fixed `no-unused-vars` errors for the `taskModal` variable in `frontend/src/pages/__tests__/ProjectViewPage.test.jsx` by removing the unused variable assignments where appropriate.

These changes aim to resolve the remaining CI failures and improve overall code health.