### PR TITLE
Fix: Resolve CI linting and formatting errors

### DIFF
--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+ignore = E203, W503

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -20,10 +20,7 @@ api_bp = Blueprint("api", __name__, url_prefix="/api")
 
 @api_bp.route("/health", methods=["GET"])
 def health_check():
-    return jsonify({
-        "status": "healthy",
-        "message": "API is up and running!"
-    }), 200
+    return jsonify({"status": "healthy", "message": "API is up and running!"}), 200
 
 
 # Test/Protected Route (can be removed or kept for testing)
@@ -52,8 +49,7 @@ def create_project():
     name = data["name"].strip()
     description = data.get("description", "").strip()
 
-    project = Project(name=name, description=description,
-                      user_id=current_user_id)
+    project = Project(name=name, description=description, user_id=current_user_id)
     db.session.add(project)
     db.session.commit()
 
@@ -261,12 +257,14 @@ def create_task(stage_id):
             due_date_obj = datetime.fromisoformat(due_date_str)
         except ValueError:
             return (
-                jsonify({
-                    "message": (
-                        "Invalid due_date format. Use ISO format "
-                        "(YYYY-MM-DDTHH:MM:SS) or (YYYY-MM-DD)."
-                    )
-                }),
+                jsonify(
+                    {
+                        "message": (
+                            "Invalid due_date format. Use ISO format "
+                            "(YYYY-MM-DDTHH:MM:SS) or (YYYY-MM-DD)."
+                        )
+                    }
+                ),
                 400,
             )
 
@@ -363,12 +361,14 @@ def update_task(task_id):
                 task.due_date = datetime.fromisoformat(due_date_str)
             except ValueError:
                 return (
-                    jsonify({
-                        "message": (
-                            "Invalid due_date format. Use ISO format "
-                            "(YYYY-MM-DDTHH:MM:SS) or (YYYY-MM-DD)."
-                        )
-                    }),
+                    jsonify(
+                        {
+                            "message": (
+                                "Invalid due_date format. Use ISO format "
+                                "(YYYY-MM-DDTHH:MM:SS) or (YYYY-MM-DD)."
+                            )
+                        }
+                    ),
                     400,
                 )
         else:  # Allow clearing due_date
@@ -382,9 +382,7 @@ def update_task(task_id):
             if not new_stage:
                 return jsonify({"message": "New stage not found"}), 404
             if new_stage.project.user_id != current_user_id:
-                return jsonify({
-                    "message": "Access forbidden to new stage"
-                }), 403
+                return jsonify({"message": "Access forbidden to new stage"}), 403
             task.stage_id = new_stage_id
             updated = True
 
@@ -394,8 +392,7 @@ def update_task(task_id):
         record_activity(
             action_type="TASK_UPDATED",
             description=(
-                f"User '{user.username}' updated task "
-                f"'{task.content[:30]}...'"
+                f"User '{user.username}' updated task " f"'{task.content[:30]}...'"
             ),
             user_id=current_user_id,
             project_id=task.stage.project.id,
@@ -454,9 +451,10 @@ def create_subtask(task_id):
     order = data.get("order")  # Can be None
 
     if not isinstance(completed, bool):
-        return jsonify({
-            "message": "Invalid format for completed flag, must be boolean."
-        }), 400
+        return (
+            jsonify({"message": "Invalid format for completed flag, must be boolean."}),
+            400,
+        )
 
     subtask = SubTask(
         content=content,
@@ -510,9 +508,12 @@ def update_subtask(subtask_id):
     if "completed" in data:
         completed_val = data["completed"]
         if not isinstance(completed_val, bool):
-            return jsonify({
-                "message": "Invalid format for completed flag, must be boolean."
-            }), 400
+            return (
+                jsonify(
+                    {"message": "Invalid format for completed flag, must be boolean."}
+                ),
+                400,
+            )
         subtask.completed = completed_val
         updated = True
     if "order" in data:
@@ -561,8 +562,7 @@ def create_comment(task_id):
 
     content = data["content"].strip()
 
-    comment = Comment(content=content, task_id=task.id,
-                      user_id=current_user_id)
+    comment = Comment(content=content, task_id=task.id, user_id=current_user_id)
     db.session.add(comment)
     db.session.commit()
 
@@ -570,8 +570,7 @@ def create_comment(task_id):
     record_activity(
         action_type="COMMENT_ADDED",
         description=(
-            f"User '{user.username}' commented on task "
-            f"'{task.content[:30]}...'"
+            f"User '{user.username}' commented on task " f"'{task.content[:30]}...'"
         ),
         user_id=current_user_id,
         project_id=task.stage.project.id,
@@ -658,9 +657,7 @@ def create_tag():
         return jsonify({"message": "Tag name is required"}), 400
 
     name = data["name"].strip()
-    existing_tag = Tag.query.filter(
-        db.func.lower(Tag.name) == name.lower()
-    ).first()
+    existing_tag = Tag.query.filter(db.func.lower(Tag.name) == name.lower()).first()
 
     if existing_tag:
         return jsonify(existing_tag.to_dict()), 200
@@ -673,16 +670,15 @@ def create_tag():
         IntegrityError
     ):  # Handles potential race conditions if another request creates the same tag
         db.session.rollback()
-        existing_tag = Tag.query.filter(
-            db.func.lower(Tag.name) == name.lower()
-        ).first()
+        existing_tag = Tag.query.filter(db.func.lower(Tag.name) == name.lower()).first()
         if existing_tag:
             return jsonify(existing_tag.to_dict()), 200
         else:
             # This case should ideally not be reached
-            return jsonify({
-                "message": "Error creating tag, possibly due to a conflict."
-            }), 500
+            return (
+                jsonify({"message": "Error creating tag, possibly due to a conflict."}),
+                500,
+            )
 
     return jsonify(tag.to_dict()), 201
 
@@ -736,9 +732,7 @@ def add_tag_to_task(task_id):
             jsonify(
                 {
                     "message": "Task already has this tag",
-                    "task": task.to_dict(
-                        include_subtasks=True, include_tags=True
-                    ),
+                    "task": task.to_dict(include_subtasks=True, include_tags=True),
                 }
             ),
             200,
@@ -758,9 +752,7 @@ def add_tag_to_task(task_id):
         project_id=task.stage.project.id,
         task_id=task.id,
     )
-    return jsonify(
-        task.to_dict(include_subtasks=True, include_tags=True)
-    ), 200
+    return jsonify(task.to_dict(include_subtasks=True, include_tags=True)), 200
 
 
 @api_bp.route("/tasks/<int:task_id>/tags/<int:tag_id>", methods=["DELETE"])

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -13,8 +13,7 @@ class User(db.Model):
     )
     projects = db.relationship("Project", backref="author", lazy="dynamic")
     comments = db.relationship("Comment", backref="commenter", lazy="dynamic")
-    activity_logs = db.relationship(
-        "ActivityLog", backref="user", lazy="dynamic")
+    activity_logs = db.relationship("ActivityLog", backref="user", lazy="dynamic")
 
     def set_password(self, password):
         from werkzeug.security import generate_password_hash
@@ -77,8 +76,7 @@ class Project(db.Model):
 class Stage(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
-    project_id = db.Column(db.Integer, db.ForeignKey(
-        "project.id"), nullable=False)
+    project_id = db.Column(db.Integer, db.ForeignKey("project.id"), nullable=False)
     order = db.Column(db.Integer, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(
@@ -153,9 +151,7 @@ class Task(db.Model):
         }
         if include_subtasks:
             subtasks_query = self.subtasks.order_by(SubTask.order).all()
-            data["subtasks"] = [
-                subtask.to_dict() for subtask in subtasks_query
-            ]
+            data["subtasks"] = [subtask.to_dict() for subtask in subtasks_query]
         return data
 
 
@@ -173,8 +169,7 @@ class Tag(db.Model):
 # Association table for Task and Tag many-to-many relationship
 task_tag = db.Table(
     "task_tag",
-    db.Column("task_id", db.Integer, db.ForeignKey(
-        "task.id"), primary_key=True),
+    db.Column("task_id", db.Integer, db.ForeignKey("task.id"), primary_key=True),
     db.Column("tag_id", db.Integer, db.ForeignKey("tag.id"), primary_key=True),
 )
 
@@ -188,8 +183,7 @@ class ActivityLog(db.Model):
         db.Text, nullable=False
     )  # e.g., "User 'X' created task 'Y'"
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    project_id = db.Column(
-        db.Integer, db.ForeignKey("project.id"), nullable=True)
+    project_id = db.Column(db.Integer, db.ForeignKey("project.id"), nullable=True)
     task_id = db.Column(db.Integer, db.ForeignKey("task.id"), nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -234,21 +228,16 @@ class Comment(db.Model):
                 self.commenter.username if self.commenter else "Unknown"
             ),
             # Added None check for safety
-            "created_at": (
-                self.created_at.isoformat() if self.created_at else None
-            ),
+            "created_at": (self.created_at.isoformat() if self.created_at else None),
             # Added None check for safety
-            "updated_at": (
-                self.updated_at.isoformat() if self.updated_at else None
-            ),
+            "updated_at": (self.updated_at.isoformat() if self.updated_at else None),
         }
 
 
 class SubTask(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.Text, nullable=False)
-    parent_task_id = db.Column(
-        db.Integer, db.ForeignKey("task.id"), nullable=False)
+    parent_task_id = db.Column(db.Integer, db.ForeignKey("task.id"), nullable=False)
     completed = db.Column(db.Boolean, default=False)
     order = db.Column(db.Integer, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -64,8 +64,7 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, target_metadata=get_metadata(),
-                      literal_binds=True)
+    context.configure(url=url, target_metadata=get_metadata(), literal_binds=True)
 
     with context.begin_transaction():
         context.run_migrations()

--- a/backend/tests/test_activity_log_api.py
+++ b/backend/tests/test_activity_log_api.py
@@ -44,8 +44,7 @@ def test_get_project_activities_success(
 
     # Find PROJECT_CREATED activity
     project_created_activity = next(
-        (act for act in activities if act["action_type"]
-         == "PROJECT_CREATED"), None
+        (act for act in activities if act["action_type"] == "PROJECT_CREATED"), None
     )
     assert project_created_activity is not None
     desc_str = f"User '{username}' created project '{project_name}'"
@@ -55,8 +54,7 @@ def test_get_project_activities_success(
 
     # Find TASK_CREATED activity
     task_created_activity = next(
-        (act for act in activities if act["action_type"]
-         == "TASK_CREATED"), None
+        (act for act in activities if act["action_type"] == "TASK_CREATED"), None
     )
     assert task_created_activity is not None
     desc_str = (
@@ -70,8 +68,7 @@ def test_get_project_activities_success(
 
     # Find COMMENT_ADDED activity
     comment_added_activity = next(
-        (act for act in activities if act["action_type"]
-         == "COMMENT_ADDED"), None
+        (act for act in activities if act["action_type"] == "COMMENT_ADDED"), None
     )
     assert comment_added_activity is not None
     desc_str = f"User '{username}' commented on task '{task_content_ellipsis}'"
@@ -119,13 +116,10 @@ def test_get_task_activities_success(
 
     # TASK_UPDATED should be the most recent
     task_updated_activity = next(
-        (act for act in activities if act["action_type"]
-         == "TASK_UPDATED"), None
+        (act for act in activities if act["action_type"] == "TASK_UPDATED"), None
     )
     assert task_updated_activity is not None
-    desc_str = (
-        f"User '{username}' updated task '{updated_task_content[:30]}...'"
-    )
+    desc_str = f"User '{username}' updated task '{updated_task_content[:30]}...'"
     assert desc_str in task_updated_activity["description"]
     assert task_updated_activity["user_username"] == username
     assert task_updated_activity["task_id"] == task_id
@@ -133,16 +127,13 @@ def test_get_task_activities_success(
 
     # COMMENT_ADDED
     comment_added_activity = next(
-        (act for act in activities if act["action_type"]
-         == "COMMENT_ADDED"), None
+        (act for act in activities if act["action_type"] == "COMMENT_ADDED"), None
     )
     assert comment_added_activity is not None
     # Note: The description for comment activity uses the task content *at the time of commenting*.
     # If the task was updated after the comment, the description reflects the older task content.
     # Here, task_content_ellipsis is the original content. The update happened *after* the comment.
-    desc_str = (
-        f"User '{username}' commented on task '{task_content_ellipsis}'"
-    )
+    desc_str = f"User '{username}' commented on task '{task_content_ellipsis}'"
     assert desc_str in comment_added_activity["description"]
     assert comment_added_activity["user_username"] == username
     assert comment_added_activity["task_id"] == task_id
@@ -150,8 +141,7 @@ def test_get_task_activities_success(
 
     # TASK_CREATED
     task_created_activity = next(
-        (act for act in activities if act["action_type"]
-         == "TASK_CREATED"), None
+        (act for act in activities if act["action_type"] == "TASK_CREATED"), None
     )
     assert task_created_activity is not None
     assert task_created_activity["user_username"] == username
@@ -170,8 +160,7 @@ def test_get_activities_non_existent_project(test_client, auth_headers):
 
 def test_get_activities_non_existent_task(test_client, auth_headers):
     request_headers = {"Authorization": auth_headers["Authorization"]}
-    response = test_client.get(
-        "/api/tasks/99998/activities", headers=request_headers)
+    response = test_client.get("/api/tasks/99998/activities", headers=request_headers)
     assert response.status_code == 404
     assert response.json["message"] == "Task not found"
 
@@ -180,8 +169,7 @@ def test_get_activities_unauthorized_no_token(test_client, created_task_data):
     project_id = created_task_data["project_id"]
     task_id = created_task_data["task_id"]
 
-    response_project = test_client.get(
-        f"/api/projects/{project_id}/activities")
+    response_project = test_client.get(f"/api/projects/{project_id}/activities")
     assert response_project.status_code == 401
 
     response_task = test_client.get(f"/api/tasks/{task_id}/activities")
@@ -297,9 +285,7 @@ def test_task_deletion_logs_activity(
             delete_activity_found = True
             assert f"User '{username}' deleted task" in activity["description"]
             break
-    assert delete_activity_found, (
-        "TASK_DELETED activity not found for deleted task"
-    )
+    assert delete_activity_found, "TASK_DELETED activity not found for deleted task"
 
     # Task activities endpoint for the deleted task should ideally be 404 or return specific logs
     # For now, we'll assume the task is gone, so its specific activity log might not be the primary check point after deletion

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -100,8 +100,7 @@ def test_login_incorrect_password(test_client, db_session):
 
 
 def test_login_missing_fields(test_client):
-    response = login_user(
-        test_client, "someuser@example.com", "")  # Missing password
+    response = login_user(test_client, "someuser@example.com", "")  # Missing password
     assert response.status_code == 400
     assert response.json["message"] == "Missing email or password"
 
@@ -143,10 +142,7 @@ def test_protected_route_with_invalid_token(test_client):
         "Not enough segments",
         "Invalid token format",
     ]
-    assert (
-        response.json["msg"] in expected_msgs
-        or "Invalid" in response.json["msg"]
-    )
+    assert response.json["msg"] in expected_msgs or "Invalid" in response.json["msg"]
     # The exact message can vary based on the nature of the invalid token.
     # For a simple non-JWT string, it's often "Invalid header padding" or "Not enough segments".
     # If it's a malformed JWT, it could be other messages.
@@ -162,8 +158,7 @@ def test_logout(test_client, db_session):
     access_token = login_response.json["access_token"]
 
     headers = {"Authorization": f"Bearer {access_token}"}
-    response = test_client.post(
-        "/api/auth/logout", headers=headers)  # POST for logout
+    response = test_client.post("/api/auth/logout", headers=headers)  # POST for logout
     assert response.status_code == 200
     assert (
         response.json["message"]

--- a/backend/tests/test_comments_api.py
+++ b/backend/tests/test_comments_api.py
@@ -126,11 +126,8 @@ def another_user_auth_headers(test_client, db_session):  # Added db_session
     login_response = test_client.post(
         "/api/auth/login", json={"email": email, "password": password}
     )
-    assert (
-        login_response.status_code == 200
-    ), (
-        f"Login failed for another_user: "
-        f"{login_response.json}"
+    assert login_response.status_code == 200, (
+        f"Login failed for another_user: " f"{login_response.json}"
     )
     access_token = login_response.json["access_token"]
     return {"Authorization": f"Bearer {access_token}"}
@@ -226,8 +223,7 @@ def test_create_comment_activity_log(
             comment_activity_found = True
             break
     assert comment_activity_found, (
-        "COMMENT_ADDED activity not found for new comment in project "
-        "activities"
+        "COMMENT_ADDED activity not found for new comment in project " "activities"
     )
 
     # Check activity log for the task
@@ -248,6 +244,5 @@ def test_create_comment_activity_log(
             task_comment_activity_found = True
             break
     assert task_comment_activity_found, (
-        "COMMENT_ADDED activity not found for new comment on task "
-        "activities"
+        "COMMENT_ADDED activity not found for new comment on task " "activities"
     )

--- a/backend/tests/test_tags_api.py
+++ b/backend/tests/test_tags_api.py
@@ -46,8 +46,7 @@ def test_create_and_list_tags(test_client, auth_headers, db_session):
         len(tags) >= 2
     )  # Could be more if other tests created tags and DB is not perfectly isolated by function
 
-    found_tag1 = any(t["name"] == tag_name1 and t["id"]
-                     == tag1_id for t in tags)
+    found_tag1 = any(t["name"] == tag_name1 and t["id"] == tag1_id for t in tags)
     found_tag2 = any(t["name"] == tag_name2 for t in tags)
     assert found_tag1
     assert found_tag2
@@ -112,8 +111,7 @@ def test_add_tag_to_task_by_id_and_name(
     task_data_2 = response_add_by_name.json
     assert len(task_data_2["tags"]) == 2
 
-    newly_added_tag = next(
-        t for t in task_data_2["tags"] if t["name"] == tag_name_new)
+    newly_added_tag = next(t for t in task_data_2["tags"] if t["name"] == tag_name_new)
     assert newly_added_tag is not None
 
     # Verify tag was created in DB
@@ -149,8 +147,7 @@ def test_add_tag_to_task_invalid_input(
     task_id = created_task_for_tags["task_id"]
 
     # No tag_id or tag_name
-    response = test_client.post(
-        f"/api/tasks/{task_id}/tags", headers=headers, json={})
+    response = test_client.post(f"/api/tasks/{task_id}/tags", headers=headers, json={})
     assert response.status_code == 400
     assert response.json["message"] == "Either tag_name or tag_id is required"
 
@@ -192,11 +189,9 @@ def test_remove_tag_from_task(
     # Add two tags first
     tag1_name = "TagToRemove1"
     tag2_name = "TagToKeep"
-    tag1_res = test_client.post(
-        "/api/tags", headers=headers, json={"name": tag1_name})
+    tag1_res = test_client.post("/api/tags", headers=headers, json={"name": tag1_name})
     tag1_id = tag1_res.json["id"]
-    tag2_res = test_client.post(
-        "/api/tags", headers=headers, json={"name": tag2_name})
+    tag2_res = test_client.post("/api/tags", headers=headers, json={"name": tag2_name})
     tag2_id = tag2_res.json["id"]
 
     test_client.post(
@@ -206,8 +201,7 @@ def test_remove_tag_from_task(
         f"/api/tasks/{task_id}/tags", headers=headers, json={"tag_id": tag2_id}
     )
 
-    task_res_before_delete = test_client.get(
-        f"/api/tasks/{task_id}", headers=headers)
+    task_res_before_delete = test_client.get(f"/api/tasks/{task_id}", headers=headers)
     assert len(task_res_before_delete.json["tags"]) == 2
 
     # Remove tag1
@@ -217,8 +211,7 @@ def test_remove_tag_from_task(
     assert response_delete.status_code == 204
 
     # Verify tag removed from task
-    task_res_after_delete = test_client.get(
-        f"/api/tasks/{task_id}", headers=headers)
+    task_res_after_delete = test_client.get(f"/api/tasks/{task_id}", headers=headers)
     assert len(task_res_after_delete.json["tags"]) == 1
     assert task_res_after_delete.json["tags"][0]["id"] == tag2_id
 
@@ -231,9 +224,7 @@ def test_remove_tag_from_task(
         and a["task_id"] == task_id
         and f"removed tag '{tag1_name}'" in a["description"]
         for a in project_activities
-    ), (
-        "TAG_REMOVED_FROM_TASK activity not found"
-    )
+    ), "TAG_REMOVED_FROM_TASK activity not found"
 
     # Attempt to remove a tag not on the task (or already removed)
     response_delete_again = test_client.delete(
@@ -264,19 +255,14 @@ def test_remove_tag_unauthorized_or_forbidden(
     )
 
     # No token
-    response_no_token = test_client.delete(
-        f"/api/tasks/{task_id}/tags/{tag_id}")
+    response_no_token = test_client.delete(f"/api/tasks/{task_id}/tags/{tag_id}")
     assert response_no_token.status_code == 401
 
     # Different user
     email_other = "other_tags_user@example.com"
     test_client.post(
         "/api/auth/register",
-        json={
-            "username": "other_tags",
-            "email": email_other,
-            "password": "opass"
-        },
+        json={"username": "other_tags", "email": email_other, "password": "opass"},
     )
     login_res_other = test_client.post(
         "/api/auth/login", json={"email": email_other, "password": "opass"}
@@ -301,16 +287,14 @@ def test_task_to_dict_includes_tags(
     # Add some tags
     tag_names = ["AlphaTag", "BetaTag"]
     for name in tag_names:
-        tag_res = test_client.post(
-            "/api/tags", headers=headers, json={"name": name})
+        tag_res = test_client.post("/api/tags", headers=headers, json={"name": name})
         tag_id = tag_res.json["id"]
         test_client.post(
             f"/api/tasks/{task_id}/tags", headers=headers, json={"tag_id": tag_id}
         )
 
     # Fetch the task directly
-    response_get_task = test_client.get(
-        f"/api/tasks/{task_id}", headers=headers)
+    response_get_task = test_client.get(f"/api/tasks/{task_id}", headers=headers)
     assert response_get_task.status_code == 200
     task_data = response_get_task.json
 
@@ -384,10 +368,7 @@ def test_add_tag_by_mixed_case_name(
     # Verify no new tag was created
     tags_list_res = test_client.get("/api/tags", headers=headers)
     tags_in_db = tags_list_res.json
-    count = sum(
-        1 for t in tags_in_db
-        if t["name"].lower() == original_tag_name.lower()
-    )
+    count = sum(1 for t in tags_in_db if t["name"].lower() == original_tag_name.lower())
     assert count == 1
 
     # 3. Add another tag by name, this time a completely new one with mixed case
@@ -405,7 +386,6 @@ def test_add_tag_by_mixed_case_name(
     assert added_tag_info is not None  # Tag was created with the provided casing
 
     # Verify it was created with the given casing
-    tag_db_check = db_session.query(Tag).filter_by(
-        id=added_tag_info["id"]).first()
+    tag_db_check = db_session.query(Tag).filter_by(id=added_tag_info["id"]).first()
     assert tag_db_check is not None
     assert tag_db_check.name == new_mixed_name

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,7 +1,7 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
 
 export default [
   { ignores: ['dist'] },
@@ -30,4 +30,4 @@ export default [
       ],
     },
   },
-]
+];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
         "msw": "^2.8.4",
+        "prettier": "^3.5.3",
         "vite": "^6.3.5",
         "vitest": "^3.1.4"
       }
@@ -3270,6 +3271,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "axios": "^1.9.0",
@@ -28,6 +30,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "msw": "^2.8.4",
+    "prettier": "^3.5.3",
     "vite": "^6.3.5",
     "vitest": "^3.1.4"
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,7 @@ import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import NotFoundPage from './pages/NotFoundPage';
-import ProtectedRoute from './components/ProtectedRoute'; 
+import ProtectedRoute from './components/ProtectedRoute';
 import ProjectViewPage from './pages/ProjectViewPage'; // Import ProjectViewPage
 // Import other necessary CSS or global styles
 import './App.css'; // Assuming some global styles
@@ -25,13 +25,13 @@ const router = createBrowserRouter([
       },
       { path: 'login', element: <LoginPage /> },
       { path: 'register', element: <RegisterPage /> },
-      { 
+      {
         path: 'project/:projectId', // Route for viewing a single project
         element: (
           <ProtectedRoute>
             <ProjectViewPage />
           </ProtectedRoute>
-        ) 
+        ),
       },
       // More routes will be added here for projects, tasks etc.
       // These will also likely be wrapped in <ProtectedRoute>
@@ -40,7 +40,7 @@ const router = createBrowserRouter([
   {
     path: '*', // Catch-all for 404
     element: <NotFoundPage />,
-  }
+  },
 ]);
 
 function App() {

--- a/frontend/src/components/ActivityLogItem.css
+++ b/frontend/src/components/ActivityLogItem.css
@@ -21,7 +21,8 @@
   align-items: center;
 }
 
-.activity-user { /* If we decide to display user separately */
+.activity-user {
+  /* If we decide to display user separately */
   font-weight: 500;
   color: #555;
   margin-right: 8px;

--- a/frontend/src/components/ActivityLogItem.jsx
+++ b/frontend/src/components/ActivityLogItem.jsx
@@ -6,18 +6,21 @@ const ActivityLogItem = ({ activity }) => {
     if (!isoString) return 'Date not available';
     try {
       const date = new Date(isoString);
-      return date.toLocaleString(undefined, { 
-        year: 'numeric', month: 'short', day: 'numeric', 
-        hour: '2-digit', minute: '2-digit' 
+      return date.toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
       });
-    // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line no-unused-vars
     } catch (e) {
       return 'Invalid date';
     }
   };
 
   // Backend ActivityLog.to_dict() includes:
-  // 'id', 'action_type', 'description', 'user_id', 
+  // 'id', 'action_type', 'description', 'user_id',
   // 'user_username', 'project_id', 'task_id', 'created_at'
 
   return (
@@ -27,7 +30,9 @@ const ActivityLogItem = ({ activity }) => {
         {/* user_username is part of the description as per backend, 
             but also available directly if needed for different styling */}
         {/* <span className="activity-user">{activity.user_username}</span> */}
-        <span className="activity-timestamp">{formatDate(activity.created_at)}</span>
+        <span className="activity-timestamp">
+          {formatDate(activity.created_at)}
+        </span>
       </div>
     </div>
   );

--- a/frontend/src/components/ActivityLogList.jsx
+++ b/frontend/src/components/ActivityLogList.jsx
@@ -8,7 +8,11 @@ const ActivityLogList = ({ activities, loading, error }) => {
   }
 
   if (error) {
-    return <p className="activity-list-message activity-list-error">Error loading activities: {error}</p>;
+    return (
+      <p className="activity-list-message activity-list-error">
+        Error loading activities: {error}
+      </p>
+    );
   }
 
   if (!activities || activities.length === 0) {
@@ -17,7 +21,7 @@ const ActivityLogList = ({ activities, loading, error }) => {
 
   return (
     <div className="activity-log-list">
-      {activities.map(activity => (
+      {activities.map((activity) => (
         <ActivityLogItem key={activity.id} activity={activity} />
       ))}
     </div>

--- a/frontend/src/components/CommentForm.jsx
+++ b/frontend/src/components/CommentForm.jsx
@@ -18,11 +18,11 @@ const CommentForm = ({ taskId, onCommentAdded }) => {
 
     try {
       // onCommentAdded is expected to be an async function that handles the API call
-      await onCommentAdded(taskId, content); 
+      await onCommentAdded(taskId, content);
       setContent(''); // Clear input after successful submission
     } catch (err) {
       setError(err.message || 'Failed to add comment. Please try again.');
-      console.error("Failed to add comment:", err);
+      console.error('Failed to add comment:', err);
     } finally {
       setIsSubmitting(false);
     }
@@ -39,8 +39,8 @@ const CommentForm = ({ taskId, onCommentAdded }) => {
         rows="3"
         disabled={isSubmitting}
       />
-      <button 
-        type="submit" 
+      <button
+        type="submit"
         className="comment-submit-button"
         disabled={isSubmitting || !content.trim()}
       >

--- a/frontend/src/components/CommentItem.css
+++ b/frontend/src/components/CommentItem.css
@@ -4,7 +4,7 @@
   border-radius: 4px;
   padding: 10px 12px;
   margin-bottom: 10px;
-  box-shadow: 0 1px 1px rgba(0,0,0,0.03);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.03);
 }
 
 .comment-header {

--- a/frontend/src/components/CommentItem.jsx
+++ b/frontend/src/components/CommentItem.jsx
@@ -6,11 +6,14 @@ const CommentItem = ({ comment }) => {
     if (!isoString) return 'Date not available';
     try {
       const date = new Date(isoString);
-      return date.toLocaleString(undefined, { 
-        year: 'numeric', month: 'short', day: 'numeric', 
-        hour: '2-digit', minute: '2-digit' 
+      return date.toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
       });
-    // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line no-unused-vars
     } catch (e) {
       return 'Invalid date';
     }
@@ -38,13 +41,16 @@ const CommentItem = ({ comment }) => {
   // }
   // So, `commenter_username` is NOT directly available. This is a limitation.
   // Backend Comment.to_dict() now includes `commenter_username`.
-  const commenterName = comment.commenter_username || `User ID: ${comment.user_id}`; // Fallback if still missing for some reason
+  const commenterName =
+    comment.commenter_username || `User ID: ${comment.user_id}`; // Fallback if still missing for some reason
 
   return (
     <div className="comment-item">
       <div className="comment-header">
         <span className="commenter-name">{commenterName}</span>
-        <span className="comment-timestamp">{formatDate(comment.created_at)}</span>
+        <span className="comment-timestamp">
+          {formatDate(comment.created_at)}
+        </span>
       </div>
       <p className="comment-content">{comment.content}</p>
     </div>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -14,9 +14,23 @@ const Layout = () => {
 
   return (
     <>
-      <header style={{ background: '#f0f0f0', padding: '1rem', marginBottom: '1rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <header
+        style={{
+          background: '#f0f0f0',
+          padding: '1rem',
+          marginBottom: '1rem',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         <nav>
-          <Link to="/" style={{ marginRight: '1rem', fontWeight: 'bold', color: '#333' }}>Kanban App</Link>
+          <Link
+            to="/"
+            style={{ marginRight: '1rem', fontWeight: 'bold', color: '#333' }}
+          >
+            Kanban App
+          </Link>
           {isAuthenticated && (
             <>
               {/* Add links to protected areas like Projects, Dashboard etc. here */}
@@ -31,16 +45,29 @@ const Layout = () => {
             </Button>
           ) : (
             <>
-              <Link to="/login" style={{ marginRight: '1rem' }}>Login</Link>
+              <Link to="/login" style={{ marginRight: '1rem' }}>
+                Login
+              </Link>
               <Link to="/register">Register</Link>
             </>
           )}
         </nav>
       </header>
-      <main style={{ padding: '1rem', flexGrow: 1 }}> {/* Added flexGrow to push footer down */}
+      <main style={{ padding: '1rem', flexGrow: 1 }}>
+        {' '}
+        {/* Added flexGrow to push footer down */}
         <Outlet /> {/* Child routes will render here */}
       </main>
-      <footer style={{ background: '#f0f0f0', padding: '1rem', marginTop: 'auto', textAlign: 'center' }}> {/* Changed marginTop to auto */}
+      <footer
+        style={{
+          background: '#f0f0f0',
+          padding: '1rem',
+          marginTop: 'auto',
+          textAlign: 'center',
+        }}
+      >
+        {' '}
+        {/* Changed marginTop to auto */}
         <p>&copy; 2024 Kanban App</p>
       </footer>
     </>

--- a/frontend/src/components/StageColumn.css
+++ b/frontend/src/components/StageColumn.css
@@ -7,7 +7,7 @@
   padding: 8px;
   width: 280px; /* Fixed width for each column */
   min-height: 300px; /* Minimum height */
-  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   flex-shrink: 0; /* Prevent columns from shrinking */
 }
 

--- a/frontend/src/components/StageColumn.jsx
+++ b/frontend/src/components/StageColumn.jsx
@@ -6,14 +6,8 @@ const StageColumn = ({ stage, onAddTask, onEditTask }) => {
   return (
     <div className="stage-column">
       <h3 className="stage-title">{stage.name}</h3>
-      <TaskList 
-        tasks={stage.tasks || []} 
-        onEditTask={onEditTask} 
-      />
-      <button 
-        className="add-task-button"
-        onClick={() => onAddTask(stage.id)}
-      >
+      <TaskList tasks={stage.tasks || []} onEditTask={onEditTask} />
+      <button className="add-task-button" onClick={() => onAddTask(stage.id)}>
         + Add Task
       </button>
     </div>

--- a/frontend/src/components/TagManager.jsx
+++ b/frontend/src/components/TagManager.jsx
@@ -15,7 +15,7 @@ const TagManager = ({ task, onTaskTagsUpdated }) => {
       const response = await apiClient.get('/tags');
       setAllTags(response.data || []);
     } catch (err) {
-      console.error("Failed to fetch all tags:", err);
+      console.error('Failed to fetch all tags:', err);
       // Non-critical, user can still type tags. Maybe a small error message.
       setError('Could not load suggested tags.');
     } finally {
@@ -32,10 +32,15 @@ const TagManager = ({ task, onTaskTagsUpdated }) => {
     if (!newTagName.trim()) return;
 
     // Prevent adding a tag if it's already on the task (case-insensitive check)
-    if (task.tags && task.tags.some(tag => tag.name.toLowerCase() === newTagName.trim().toLowerCase())) {
-        setNewTagName(''); // Clear input
-        alert(`Tag "${newTagName.trim()}" is already on this task.`);
-        return;
+    if (
+      task.tags &&
+      task.tags.some(
+        (tag) => tag.name.toLowerCase() === newTagName.trim().toLowerCase(),
+      )
+    ) {
+      setNewTagName(''); // Clear input
+      alert(`Tag "${newTagName.trim()}" is already on this task.`);
+      return;
     }
 
     setIsSubmitting(true);
@@ -43,13 +48,15 @@ const TagManager = ({ task, onTaskTagsUpdated }) => {
     try {
       // The backend POST /api/tasks/<task_id>/tags endpoint handles tag creation if it doesn't exist
       // and then associates it. It expects {'tag_name': 'name'} or {'tag_id': id}
-      const response = await apiClient.post(`/tasks/${task.id}/tags`, { tag_name: newTagName.trim() });
+      const response = await apiClient.post(`/tasks/${task.id}/tags`, {
+        tag_name: newTagName.trim(),
+      });
       setNewTagName(''); // Clear input
       if (onTaskTagsUpdated) {
         onTaskTagsUpdated(response.data.tags); // Pass the updated list of tags for the task
       }
     } catch (err) {
-      console.error("Failed to add tag:", err);
+      console.error('Failed to add tag:', err);
       setError(err.response?.data?.message || 'Could not add tag.');
     } finally {
       setIsSubmitting(false);
@@ -63,12 +70,12 @@ const TagManager = ({ task, onTaskTagsUpdated }) => {
     try {
       await apiClient.delete(`/tasks/${task.id}/tags/${tagIdToRemove}`);
       // The response from DELETE is 204 No Content. We need to manually update the local task's tags.
-      const updatedTags = task.tags.filter(tag => tag.id !== tagIdToRemove);
+      const updatedTags = task.tags.filter((tag) => tag.id !== tagIdToRemove);
       if (onTaskTagsUpdated) {
         onTaskTagsUpdated(updatedTags);
       }
     } catch (err) {
-      console.error("Failed to remove tag:", err);
+      console.error('Failed to remove tag:', err);
       setError(err.response?.data?.message || 'Could not remove tag.');
     }
   };
@@ -79,11 +86,11 @@ const TagManager = ({ task, onTaskTagsUpdated }) => {
     <div className="tag-manager-container">
       <div className="current-tags-list">
         {task.tags && task.tags.length > 0 ? (
-          task.tags.map(tag => (
+          task.tags.map((tag) => (
             <span key={tag.id} className="tag-item">
               {tag.name}
-              <button 
-                onClick={() => handleRemoveTag(tag.id)} 
+              <button
+                onClick={() => handleRemoveTag(tag.id)}
                 className="remove-tag-button"
                 title={`Remove tag "${tag.name}"`}
               >
@@ -107,16 +114,22 @@ const TagManager = ({ task, onTaskTagsUpdated }) => {
           disabled={isSubmitting}
         />
         <datalist id="all-tags-datalist">
-          {allTags.map(tag => (
+          {allTags.map((tag) => (
             <option key={tag.id} value={tag.name} />
           ))}
         </datalist>
-        <button type="submit" className="add-tag-button" disabled={isSubmitting || !newTagName.trim()}>
+        <button
+          type="submit"
+          className="add-tag-button"
+          disabled={isSubmitting || !newTagName.trim()}
+        >
           {isSubmitting ? 'Adding...' : 'Add Tag'}
         </button>
       </form>
       {error && <p className="tag-manager-error">{error}</p>}
-      {loadingAllTags && <p className="tag-manager-loading-tags">Loading available tags...</p>}
+      {loadingAllTags && (
+        <p className="tag-manager-loading-tags">Loading available tags...</p>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/TaskCard.jsx
+++ b/frontend/src/components/TaskCard.jsx
@@ -21,7 +21,7 @@ const TaskCard = ({ task, onEditTask }) => {
     color: '#555',
     marginBottom: '4px',
   };
-  
+
   const priorityColors = {
     High: 'red',
     Medium: 'orange',
@@ -35,14 +35,17 @@ const TaskCard = ({ task, onEditTask }) => {
     fontWeight: 'bold',
   };
 
-
   const formatDate = (isoString) => {
     if (!isoString) return 'Not set';
     // Basic formatting, consider a library like date-fns for more complex needs
     try {
       const date = new Date(isoString);
-      return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
-    // eslint-disable-next-line no-unused-vars
+      return date.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+      // eslint-disable-next-line no-unused-vars
     } catch (e) {
       return 'Invalid date';
     }
@@ -58,22 +61,25 @@ const TaskCard = ({ task, onEditTask }) => {
       {/* task.tags should be an array of tag objects */}
       {task.tags && task.tags.length > 0 && (
         <div style={{ marginTop: '5px' }}>
-          {task.tags.map(tag => (
-            <span key={tag.id} style={{ 
-              backgroundColor: '#e0e0e0', 
-              color: '#333',
-              padding: '2px 6px', 
-              borderRadius: '3px', 
-              fontSize: '0.8em',
-              marginRight: '4px'
-            }}>
+          {task.tags.map((tag) => (
+            <span
+              key={tag.id}
+              style={{
+                backgroundColor: '#e0e0e0',
+                color: '#333',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                fontSize: '0.8em',
+                marginRight: '4px',
+              }}
+            >
               {tag.name}
             </span>
           ))}
         </div>
       )}
-      <button 
-        onClick={() => onEditTask(task)} 
+      <button
+        onClick={() => onEditTask(task)}
         style={{ marginTop: '10px', padding: '6px 10px', cursor: 'pointer' }}
       >
         Edit

--- a/frontend/src/components/TaskList.jsx
+++ b/frontend/src/components/TaskList.jsx
@@ -3,17 +3,17 @@ import TaskCard from './TaskCard';
 
 const TaskList = ({ tasks, onEditTask }) => {
   if (!tasks || tasks.length === 0) {
-    return <p style={{ padding: '10px', color: '#777' }}>No tasks in this stage yet.</p>;
+    return (
+      <p style={{ padding: '10px', color: '#777' }}>
+        No tasks in this stage yet.
+      </p>
+    );
   }
 
   return (
     <div>
-      {tasks.map(task => (
-        <TaskCard 
-          key={task.id} 
-          task={task} 
-          onEditTask={onEditTask} 
-        />
+      {tasks.map((task) => (
+        <TaskCard key={task.id} task={task} onEditTask={onEditTask} />
       ))}
     </div>
   );

--- a/frontend/src/components/TaskModal.css
+++ b/frontend/src/components/TaskModal.css
@@ -17,7 +17,7 @@
   background: white;
   padding: 25px;
   border-radius: 8px;
-  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
   width: 90%;
   max-width: 600px; /* Slightly wider to accommodate comments */
   display: flex;
@@ -44,20 +44,20 @@
   color: #555;
 }
 
-.form-group input[type="text"],
-.form-group input[type="date"],
+.form-group input[type='text'],
+.form-group input[type='date'],
 .form-group textarea,
 .form-group select {
-  width: 100%; 
+  width: 100%;
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 4px;
-  box-sizing: border-box; 
+  box-sizing: border-box;
   font-size: 1em;
 }
 
 .form-group textarea {
-  resize: vertical; 
+  resize: vertical;
   min-height: 80px;
 }
 
@@ -76,11 +76,13 @@
   cursor: pointer;
   font-size: 1em;
   font-weight: bold;
-  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .modal-actions .button-cancel {
-  background-color: #f0f0f0; 
+  background-color: #f0f0f0;
   color: #333;
   margin-right: 10px;
 }
@@ -90,13 +92,13 @@
 }
 
 .modal-actions .button-save {
-  background-color: #007bff; 
+  background-color: #007bff;
   color: white;
 }
 
 .modal-actions .button-save:hover {
-  background-color: #0056b3; 
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  background-color: #0056b3;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 /* Modal Tabs Styling */
@@ -115,7 +117,9 @@
   color: #495057;
   border-bottom: 3px solid transparent; /* For active indicator */
   margin-right: 10px;
-  transition: color 0.2s ease, border-bottom-color 0.2s ease;
+  transition:
+    color 0.2s ease,
+    border-bottom-color 0.2s ease;
 }
 
 .modal-tabs button:hover {
@@ -132,33 +136,36 @@
 .comments-section,
 .activity-log-section {
   margin-top: 10px; /* Reduced margin as tabs provide separation */
-  padding-top: 10px; 
+  padding-top: 10px;
   /* border-top: 1px solid #dee2e6; /* No longer needed if tabs have bottom border */
 }
 
 .comments-section h4,
 .activity-log-section h4 {
   font-size: 1.2em;
-  color: #343a40; 
+  color: #343a40;
   margin-bottom: 15px;
 }
 
 .comments-list,
-.activity-log-section .activity-log-list { /* Target ActivityLogList within this section */
+.activity-log-section .activity-log-list {
+  /* Target ActivityLogList within this section */
   max-height: 250px; /* Consistent max height for scrollable content */
   overflow-y: auto;
-  padding-right: 5px; 
-  margin-bottom: 15px; 
+  padding-right: 5px;
+  margin-bottom: 15px;
 }
 
 .comments-section .error-message,
-.activity-log-section .error-message { /* Shared error message styling */
+.activity-log-section .error-message {
+  /* Shared error message styling */
   color: #dc3545;
   font-size: 0.9em;
 }
 
 .comments-section p:first-of-type, /* For "Loading..." or "No items..." */
-.activity-log-section .activity-list-message { /* Target specific message class from ActivityLogList */
+.activity-log-section .activity-list-message {
+  /* Target specific message class from ActivityLogList */
   color: #6c757d;
   font-style: italic;
 }

--- a/frontend/src/components/TaskModal.jsx
+++ b/frontend/src/components/TaskModal.jsx
@@ -5,15 +5,22 @@ import CommentForm from './CommentForm';
 import TagManager from './TagManager'; // Import TagManager
 import './TaskModal.css';
 
-const TaskModal = ({ task, stageId, isOpen, onClose, onSave, onTaskUpdated }) => {
+const TaskModal = ({
+  task,
+  stageId,
+  isOpen,
+  onClose,
+  onSave,
+  onTaskUpdated,
+}) => {
   // Task state - this will hold the current version of the task, including its tags
   const [currentTask, setCurrentTask] = useState(task);
-  
+
   // Form fields state (derived from currentTask or initial values)
   const [content, setContent] = useState('');
   const [dueDate, setDueDate] = useState('');
   const [priority, setPriority] = useState('Medium');
-  
+
   const [comments, setComments] = useState([]);
   const [loadingComments, setLoadingComments] = useState(false);
   const [commentError, setCommentError] = useState(null);
@@ -23,17 +30,20 @@ const TaskModal = ({ task, stageId, isOpen, onClose, onSave, onTaskUpdated }) =>
     setCurrentTask(task);
   }, [task]);
 
-
   const fetchComments = useCallback(async () => {
     if (currentTask && currentTask.id && isOpen) {
       setLoadingComments(true);
       setCommentError(null);
       try {
-        const response = await apiClient.get(`/tasks/${currentTask.id}/comments`);
+        const response = await apiClient.get(
+          `/tasks/${currentTask.id}/comments`,
+        );
         setComments(response.data || []);
       } catch (err) {
-        console.error("Failed to fetch comments:", err);
-        setCommentError(err.response?.data?.message || 'Could not load comments.');
+        console.error('Failed to fetch comments:', err);
+        setCommentError(
+          err.response?.data?.message || 'Could not load comments.',
+        );
       } finally {
         setLoadingComments(false);
       }
@@ -46,10 +56,13 @@ const TaskModal = ({ task, stageId, isOpen, onClose, onSave, onTaskUpdated }) =>
     if (isOpen) {
       if (currentTask) {
         setContent(currentTask.content || '');
-        setDueDate(currentTask.due_date ? currentTask.due_date.split('T')[0] : '');
+        setDueDate(
+          currentTask.due_date ? currentTask.due_date.split('T')[0] : '',
+        );
         setPriority(currentTask.priority || 'Medium');
-        fetchComments(); 
-      } else { // New task
+        fetchComments();
+      } else {
+        // New task
         setContent('');
         setDueDate('');
         setPriority('Medium');
@@ -67,12 +80,12 @@ const TaskModal = ({ task, stageId, isOpen, onClose, onSave, onTaskUpdated }) =>
       alert('Task content cannot be empty.');
       return;
     }
-    
+
     const taskDataToSave = {
       content: content.trim(),
       due_date: dueDate || null,
       priority: priority,
-      stage_id: task ? task.stage_id : stageId, 
+      stage_id: task ? task.stage_id : stageId,
     };
 
     if (task && task.id) {
@@ -84,46 +97,69 @@ const TaskModal = ({ task, stageId, isOpen, onClose, onSave, onTaskUpdated }) =>
   const handleAddComment = async (taskId, commentContent) => {
     // This function will be passed to CommentForm
     try {
-      await apiClient.post(`/tasks/${taskId}/comments`, { content: commentContent });
+      await apiClient.post(`/tasks/${taskId}/comments`, {
+        content: commentContent,
+      });
       fetchComments(); // Re-fetch comments to show the new one
-      if (onTaskUpdated) { // If ProjectViewPage needs to know task was updated (e.g. activity log changes)
+      if (onTaskUpdated) {
+        // If ProjectViewPage needs to know task was updated (e.g. activity log changes)
         onTaskUpdated();
       }
     } catch (err) {
-      console.error("Failed to add comment via TaskModal:", err);
+      console.error('Failed to add comment via TaskModal:', err);
       // Let CommentForm handle displaying its own error, or re-throw
-      throw err; 
+      throw err;
     }
   };
-  
+
   return (
     <div className="modal-overlay">
-      <div className="modal-content task-modal-content"> {/* Added specific class */}
+      <div className="modal-content task-modal-content">
+        {' '}
+        {/* Added specific class */}
         <h3>{task ? 'Edit Task' : 'Create New Task'}</h3>
         <form onSubmit={handleTaskSubmit}>
           {/* Task Form Fields */}
           <div className="form-group">
             <label htmlFor="task-content">Content:</label>
-            <textarea id="task-content" value={content} onChange={(e) => setContent(e.target.value)} required rows="3"/>
+            <textarea
+              id="task-content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              required
+              rows="3"
+            />
           </div>
           <div className="form-group">
             <label htmlFor="task-due-date">Due Date:</label>
-            <input id="task-due-date" type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
+            <input
+              id="task-due-date"
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+            />
           </div>
           <div className="form-group">
             <label htmlFor="task-priority">Priority:</label>
-            <select id="task-priority" value={priority} onChange={(e) => setPriority(e.target.value)}>
+            <select
+              id="task-priority"
+              value={priority}
+              onChange={(e) => setPriority(e.target.value)}
+            >
               <option value="Low">Low</option>
               <option value="Medium">Medium</option>
               <option value="High">High</option>
             </select>
           </div>
           <div className="modal-actions">
-            <button type="button" onClick={onClose} className="button-cancel">Cancel</button>
-            <button type="submit" className="button-save">{task ? 'Save Changes' : 'Create Task'}</button>
+            <button type="button" onClick={onClose} className="button-cancel">
+              Cancel
+            </button>
+            <button type="submit" className="button-save">
+              {task ? 'Save Changes' : 'Create Task'}
+            </button>
           </div>
         </form>
-
         {/* Comments Section - Only for existing tasks */}
         {task && task.id && (
           <div className="comments-section">
@@ -134,7 +170,7 @@ const TaskModal = ({ task, stageId, isOpen, onClose, onSave, onTaskUpdated }) =>
               <p>No comments yet.</p>
             )}
             <div className="comments-list">
-              {comments.map(comment => (
+              {comments.map((comment) => (
                 <CommentItem key={comment.id} comment={comment} />
               ))}
             </div>

--- a/frontend/src/components/__tests__/ActivityLogItem.test.jsx
+++ b/frontend/src/components/__tests__/ActivityLogItem.test.jsx
@@ -23,10 +23,16 @@ describe('ActivityLogItem', () => {
     // For simplicity, we'll check for a part of it or a general pattern.
     // The toLocaleString output depends on the node's ICU data and system locale.
     // Let's check for the presence of the date and a time-like pattern.
-    const expectedDate = new Date(mockActivity.created_at).toLocaleDateString(undefined, { 
-      year: 'numeric', month: 'short', day: 'numeric', 
-      hour: '2-digit', minute: '2-digit' 
-    });
+    const expectedDate = new Date(mockActivity.created_at).toLocaleDateString(
+      undefined,
+      {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      },
+    );
     expect(screen.getByText(expectedDate)).toBeInTheDocument();
   });
 
@@ -35,9 +41,12 @@ describe('ActivityLogItem', () => {
     render(<ActivityLogItem activity={activityWithoutDate} />);
     expect(screen.getByText('Date not available')).toBeInTheDocument();
   });
-  
+
   it('handles invalid timestamp gracefully', () => {
-    const activityWithInvalidDate = { ...mockActivity, created_at: 'invalid-date-string' };
+    const activityWithInvalidDate = {
+      ...mockActivity,
+      created_at: 'invalid-date-string',
+    };
     render(<ActivityLogItem activity={activityWithInvalidDate} />);
     expect(screen.getByText('Invalid date')).toBeInTheDocument();
   });

--- a/frontend/src/components/__tests__/ActivityLogList.test.jsx
+++ b/frontend/src/components/__tests__/ActivityLogList.test.jsx
@@ -6,7 +6,9 @@ import ActivityLogItem from '../ActivityLogItem';
 
 // Mock ActivityLogItem to simplify testing of ActivityLogList
 vi.mock('../ActivityLogItem', () => ({
-  default: ({ activity }) => <div data-testid="activity-item">{activity.description}</div>,
+  default: ({ activity }) => (
+    <div data-testid="activity-item">{activity.description}</div>
+  ),
 }));
 
 describe('ActivityLogList', () => {
@@ -21,8 +23,16 @@ describe('ActivityLogList', () => {
   });
 
   it('renders error message when error is present', () => {
-    render(<ActivityLogList activities={[]} loading={false} error="Failed to load" />);
-    expect(screen.getByText('Error loading activities: Failed to load')).toBeInTheDocument();
+    render(
+      <ActivityLogList
+        activities={[]}
+        loading={false}
+        error="Failed to load"
+      />,
+    );
+    expect(
+      screen.getByText('Error loading activities: Failed to load'),
+    ).toBeInTheDocument();
   });
 
   it('renders "No activities found" when no activities and not loading/error', () => {
@@ -31,8 +41,14 @@ describe('ActivityLogList', () => {
   });
 
   it('renders a list of ActivityLogItem components when activities are provided', () => {
-    render(<ActivityLogList activities={mockActivities} loading={false} error={null} />);
-    
+    render(
+      <ActivityLogList
+        activities={mockActivities}
+        loading={false}
+        error={null}
+      />,
+    );
+
     const items = screen.getAllByTestId('activity-item');
     expect(items).toHaveLength(mockActivities.length);
     expect(items[0]).toHaveTextContent('Activity 1');
@@ -40,10 +56,16 @@ describe('ActivityLogList', () => {
   });
 
   it('passes correct props to ActivityLogItem (verified by mock)', () => {
-    // This test relies on the mock implementation detail, 
+    // This test relies on the mock implementation detail,
     // but ensures ActivityLogList correctly maps and passes activity prop.
-    render(<ActivityLogList activities={mockActivities} loading={false} error={null} />);
-    
+    render(
+      <ActivityLogList
+        activities={mockActivities}
+        loading={false}
+        error={null}
+      />,
+    );
+
     // Check content rendered by the mock
     expect(screen.getByText(mockActivities[0].description)).toBeInTheDocument();
     expect(screen.getByText(mockActivities[1].description)).toBeInTheDocument();

--- a/frontend/src/components/__tests__/CommentForm.test.jsx
+++ b/frontend/src/components/__tests__/CommentForm.test.jsx
@@ -6,11 +6,15 @@ import CommentForm from '../CommentForm';
 
 describe('CommentForm', () => {
   const mockTaskId = 123;
-  
+
   it('renders textarea and submit button', () => {
     render(<CommentForm taskId={mockTaskId} onCommentAdded={vi.fn()} />);
-    expect(screen.getByPlaceholderText('Write a comment...')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Add Comment' })).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Write a comment...'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Add Comment' }),
+    ).toBeInTheDocument();
   });
 
   it('allows typing in the textarea', async () => {
@@ -36,8 +40,10 @@ describe('CommentForm', () => {
 
   it('calls onCommentAdded with task ID and content on submit and clears textarea', async () => {
     const mockOnCommentAdded = vi.fn(() => Promise.resolve()); // Mock returns a resolved promise
-    render(<CommentForm taskId={mockTaskId} onCommentAdded={mockOnCommentAdded} />);
-    
+    render(
+      <CommentForm taskId={mockTaskId} onCommentAdded={mockOnCommentAdded} />,
+    );
+
     const textarea = screen.getByPlaceholderText('Write a comment...');
     const submitButton = screen.getByRole('button', { name: 'Add Comment' });
     const commentText = 'A new insightful comment';
@@ -59,17 +65,23 @@ describe('CommentForm', () => {
     const submitButton = screen.getByRole('button', { name: 'Add Comment' });
     // Intentionally not typing anything or typing whitespace
     await userEvent.click(submitButton); // Should not submit due to disabled state, but let's ensure error if forced
-    
+
     // To test the internal validation message when content is empty
     fireEvent.submit(screen.getByRole('form')); // Directly trigger form submit for this check
-    
-    expect(screen.getByText('Comment content cannot be empty.')).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Comment content cannot be empty.'),
+    ).toBeInTheDocument();
   });
 
   it('displays error message if onCommentAdded throws error', async () => {
     const errorMessage = 'Network Error';
-    const mockOnCommentAdded = vi.fn(() => Promise.reject(new Error(errorMessage)));
-    render(<CommentForm taskId={mockTaskId} onCommentAdded={mockOnCommentAdded} />);
+    const mockOnCommentAdded = vi.fn(() =>
+      Promise.reject(new Error(errorMessage)),
+    );
+    render(
+      <CommentForm taskId={mockTaskId} onCommentAdded={mockOnCommentAdded} />,
+    );
 
     const textarea = screen.getByPlaceholderText('Write a comment...');
     const submitButton = screen.getByRole('button', { name: 'Add Comment' });
@@ -85,25 +97,33 @@ describe('CommentForm', () => {
   it('shows submitting state on button when submitting', async () => {
     // A promise that doesn't resolve immediately to check "Submitting..." state
     let resolveSubmission;
-    const longSubmissionPromise = new Promise(resolve => { resolveSubmission = resolve; });
+    const longSubmissionPromise = new Promise((resolve) => {
+      resolveSubmission = resolve;
+    });
     const mockOnCommentAdded = vi.fn(() => longSubmissionPromise);
 
-    render(<CommentForm taskId={mockTaskId} onCommentAdded={mockOnCommentAdded} />);
-    
+    render(
+      <CommentForm taskId={mockTaskId} onCommentAdded={mockOnCommentAdded} />,
+    );
+
     const textarea = screen.getByPlaceholderText('Write a comment...');
     const submitButton = screen.getByRole('button', { name: 'Add Comment' });
 
     await userEvent.type(textarea, 'Submitting test');
     await userEvent.click(submitButton);
 
-    expect(screen.getByRole('button', { name: 'Submitting...' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Submitting...' }),
+    ).toBeInTheDocument();
     expect(submitButton).toBeDisabled(); // Also check disabled state
     expect(textarea).toBeDisabled();
 
     // Resolve the promise to finish the test
-    resolveSubmission(); 
+    resolveSubmission();
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Add Comment' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Add Comment' }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/__tests__/CommentItem.test.jsx
+++ b/frontend/src/components/__tests__/CommentItem.test.jsx
@@ -27,20 +27,30 @@ describe('CommentItem', () => {
 
   it('renders commenter username when available', () => {
     render(<CommentItem comment={mockComment} />);
-    expect(screen.getByText(mockComment.commenter_username)).toBeInTheDocument();
+    expect(
+      screen.getByText(mockComment.commenter_username),
+    ).toBeInTheDocument();
   });
 
   it('renders User ID when commenter_username is not available', () => {
     render(<CommentItem comment={mockCommentNoUsername} />);
-    expect(screen.getByText(`User ID: ${mockCommentNoUsername.user_id}`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`User ID: ${mockCommentNoUsername.user_id}`),
+    ).toBeInTheDocument();
   });
 
   it('renders formatted timestamp correctly', () => {
     render(<CommentItem comment={mockComment} />);
-    const expectedDate = new Date(mockComment.created_at).toLocaleString(undefined, { 
-      year: 'numeric', month: 'short', day: 'numeric', 
-      hour: '2-digit', minute: '2-digit' 
-    });
+    const expectedDate = new Date(mockComment.created_at).toLocaleString(
+      undefined,
+      {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      },
+    );
     expect(screen.getByText(expectedDate)).toBeInTheDocument();
   });
 

--- a/frontend/src/components/__tests__/StageColumn.test.jsx
+++ b/frontend/src/components/__tests__/StageColumn.test.jsx
@@ -8,8 +8,12 @@ import TaskList from '../TaskList';
 vi.mock('../TaskList', () => ({
   default: ({ tasks, onEditTask }) => (
     <div data-testid="task-list">
-      {tasks.map(task => (
-        <div key={task.id} data-testid="task-in-list" onClick={() => onEditTask(task)}>
+      {tasks.map((task) => (
+        <div
+          key={task.id}
+          data-testid="task-in-list"
+          onClick={() => onEditTask(task)}
+        >
           {task.content}
         </div>
       ))}
@@ -31,22 +35,24 @@ describe('StageColumn', () => {
 
   it('renders stage title correctly', () => {
     render(
-      <StageColumn 
-        stage={mockStage} 
-        onAddTask={mockOnAddTask} 
-        onEditTask={mockOnEditTask} 
-      />
+      <StageColumn
+        stage={mockStage}
+        onAddTask={mockOnAddTask}
+        onEditTask={mockOnEditTask}
+      />,
     );
-    expect(screen.getByRole('heading', { name: mockStage.name, level: 3 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: mockStage.name, level: 3 }),
+    ).toBeInTheDocument();
   });
 
   it('renders TaskList with correct tasks', () => {
     render(
-      <StageColumn 
-        stage={mockStage} 
-        onAddTask={mockOnAddTask} 
-        onEditTask={mockOnEditTask} 
-      />
+      <StageColumn
+        stage={mockStage}
+        onAddTask={mockOnAddTask}
+        onEditTask={mockOnEditTask}
+      />,
     );
     expect(screen.getByTestId('task-list')).toBeInTheDocument();
     const tasksInList = screen.getAllByTestId('task-in-list');
@@ -54,7 +60,7 @@ describe('StageColumn', () => {
     expect(tasksInList[0]).toHaveTextContent('Task A');
     expect(tasksInList[1]).toHaveTextContent('Task B');
   });
-  
+
   it('renders TaskList with empty message if no tasks', () => {
     // To test this properly, the mock of TaskList needs to be more sophisticated
     // or we don't mock TaskList and let it render its own "no tasks" message.
@@ -63,12 +69,12 @@ describe('StageColumn', () => {
     // Let's assume TaskList's own tests cover the "no tasks" message.
     // Here we just check that an empty tasks array is passed.
     const stageWithNoTasks = { ...mockStage, tasks: [] };
-     render(
-      <StageColumn 
-        stage={stageWithNoTasks} 
-        onAddTask={mockOnAddTask} 
-        onEditTask={mockOnEditTask} 
-      />
+    render(
+      <StageColumn
+        stage={stageWithNoTasks}
+        onAddTask={mockOnAddTask}
+        onEditTask={mockOnEditTask}
+      />,
     );
     // Check that TaskList is rendered (our mock will render an empty div)
     expect(screen.getByTestId('task-list')).toBeInTheDocument();
@@ -76,14 +82,13 @@ describe('StageColumn', () => {
     expect(screen.queryAllByTestId('task-in-list')).toHaveLength(0);
   });
 
-
   it('calls onAddTask with stage ID when "Add Task" button is clicked', () => {
     render(
-      <StageColumn 
-        stage={mockStage} 
-        onAddTask={mockOnAddTask} 
-        onEditTask={mockOnEditTask} 
-      />
+      <StageColumn
+        stage={mockStage}
+        onAddTask={mockOnAddTask}
+        onEditTask={mockOnEditTask}
+      />,
     );
     const addTaskButton = screen.getByRole('button', { name: '+ Add Task' });
     fireEvent.click(addTaskButton);
@@ -93,11 +98,11 @@ describe('StageColumn', () => {
 
   it('passes onEditTask to TaskList (verified by mock interaction)', () => {
     render(
-      <StageColumn 
-        stage={mockStage} 
-        onAddTask={mockOnAddTask} 
-        onEditTask={mockOnEditTask} 
-      />
+      <StageColumn
+        stage={mockStage}
+        onAddTask={mockOnAddTask}
+        onEditTask={mockOnEditTask}
+      />,
     );
     // Simulate a click on a task within the mocked TaskList
     const tasksInList = screen.getAllByTestId('task-in-list');

--- a/frontend/src/components/__tests__/TagManager.test.jsx
+++ b/frontend/src/components/__tests__/TagManager.test.jsx
@@ -12,7 +12,6 @@ import TagManager from '../TagManager';
 // vi.spyOn(apiClient, 'post');
 // vi.spyOn(apiClient, 'delete');
 
-
 describe('TagManager', () => {
   const mockTaskWithTags = {
     id: 1,
@@ -56,57 +55,86 @@ describe('TagManager', () => {
         // For simplicity, assume currentTask.tags is the source of truth before this call
         // and return the new tag added to the existing ones.
         // This is a simplified mock; a real backend would handle tag existence.
-        
+
         // The component expects the full task object with updated tags in response.data.tags
         // Let's find the task from our mocks (or assume it's mockTaskWithTags/mockTaskWithoutTags)
         // and add the new tag to its list of tags.
         let existingTags = [];
-        if (parseInt(taskId) === mockTaskWithTags.id) existingTags = mockTaskWithTags.tags;
-        if (parseInt(taskId) === mockTaskWithoutTags.id) existingTags = mockTaskWithoutTags.tags;
+        if (parseInt(taskId) === mockTaskWithTags.id)
+          existingTags = mockTaskWithTags.tags;
+        if (parseInt(taskId) === mockTaskWithoutTags.id)
+          existingTags = mockTaskWithoutTags.tags;
 
         const updatedTaskWithNewTag = {
-            id: parseInt(taskId),
-            // ... other task properties if needed by the component from this response ...
-            tags: [...existingTags, newTag] 
+          id: parseInt(taskId),
+          // ... other task properties if needed by the component from this response ...
+          tags: [...existingTags, newTag],
         };
-        return HttpResponse.json(updatedTaskWithNewTag); 
+        return HttpResponse.json(updatedTaskWithNewTag);
       }),
       http.delete('/api/tasks/:taskId/tags/:tagId', () => {
         return new HttpResponse(null, { status: 204 });
-      })
+      }),
     );
   });
 
   it('fetches and displays available tags in datalist', async () => {
-    render(<TagManager task={mockTaskWithoutTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
-    
+    render(
+      <TagManager
+        task={mockTaskWithoutTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
+
     await waitFor(() => {
       screen.getByTestId('all-tags-datalist'); // Assuming you add data-testid to datalist
       // For some reason, directly querying datalist or its options can be tricky with RTL depending on browser/JSDOM.
       // Let's check if the input has the list attribute.
-      expect(screen.getByPlaceholderText('Add a tag...')).toHaveAttribute('list', 'all-tags-datalist');
+      expect(screen.getByPlaceholderText('Add a tag...')).toHaveAttribute(
+        'list',
+        'all-tags-datalist',
+      );
       // And if the datalist has options (this might not work reliably across all environments)
       // A more robust test might involve checking the network call or the state if exposed.
       // For now, if the fetchAllTags was called (MSW handles it), we assume options are there.
     });
     // Check if loading message for tags disappears
-    expect(screen.queryByText('Loading available tags...')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Loading available tags...'),
+    ).not.toBeInTheDocument();
   });
 
   it('displays current tags for a task with remove buttons', () => {
-    render(<TagManager task={mockTaskWithTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
+    render(
+      <TagManager
+        task={mockTaskWithTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
     expect(screen.getByText('Urgent')).toBeInTheDocument();
     expect(screen.getByText('Frontend')).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: /Remove tag/ })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: /Remove tag/ })).toHaveLength(
+      2,
+    );
   });
 
   it('displays "No tags yet." if task has no tags', () => {
-    render(<TagManager task={mockTaskWithoutTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
+    render(
+      <TagManager
+        task={mockTaskWithoutTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
     expect(screen.getByText('No tags yet.')).toBeInTheDocument();
   });
 
   it('allows adding a new tag by name', async () => {
-    render(<TagManager task={mockTaskWithoutTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
+    render(
+      <TagManager
+        task={mockTaskWithoutTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
     const input = screen.getByPlaceholderText('Add a tag...');
     const addButton = screen.getByRole('button', { name: 'Add Tag' });
     const newTagName = 'Design';
@@ -120,7 +148,7 @@ describe('TagManager', () => {
       // Our mock for POST /api/tasks/:taskId/tags returns { id, tags: [...existingTags, newTag] }
       // So we expect an array of tags.
       expect(mockOnTaskTagsUpdated).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ name: newTagName })])
+        expect.arrayContaining([expect.objectContaining({ name: newTagName })]),
       );
     });
     expect(input).toHaveValue(''); // Input should clear
@@ -130,25 +158,36 @@ describe('TagManager', () => {
     // Mock window.alert
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
 
-    render(<TagManager task={mockTaskWithTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
+    render(
+      <TagManager
+        task={mockTaskWithTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
     const input = screen.getByPlaceholderText('Add a tag...');
     const addButton = screen.getByRole('button', { name: 'Add Tag' });
-    
+
     await userEvent.type(input, 'urgent'); // Try adding "Urgent" again, but lowercase
     await userEvent.click(addButton);
 
-    expect(alertSpy).toHaveBeenCalledWith('Tag "urgent" is already on this task.');
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Tag "urgent" is already on this task.',
+    );
     expect(mockOnTaskTagsUpdated).not.toHaveBeenCalled(); // Should not call update if tag exists
     expect(input).toHaveValue(''); // Input should still clear
 
     alertSpy.mockRestore();
   });
 
-
   it('allows removing a tag', async () => {
-    render(<TagManager task={mockTaskWithTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
+    render(
+      <TagManager
+        task={mockTaskWithTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
     const removeButtons = screen.getAllByRole('button', { name: /Remove tag/ });
-    
+
     // Remove the first tag ("Urgent")
     await userEvent.click(removeButtons[0]);
 
@@ -157,7 +196,7 @@ describe('TagManager', () => {
       // Expected: called with the remaining tags
       expect(mockOnTaskTagsUpdated).toHaveBeenCalledWith(
         // mockTaskWithTags.tags[1] is 'Frontend'
-        [expect.objectContaining({ name: 'Frontend' })] 
+        [expect.objectContaining({ name: 'Frontend' })],
       );
     });
   });
@@ -165,47 +204,75 @@ describe('TagManager', () => {
   it('shows error message if adding a tag fails', async () => {
     server.use(
       http.post('/api/tasks/:taskId/tags', () => {
-        return HttpResponse.json({ message: 'Server error adding tag' }, { status: 500 });
-      })
+        return HttpResponse.json(
+          { message: 'Server error adding tag' },
+          { status: 500 },
+        );
+      }),
     );
 
-    render(<TagManager task={mockTaskWithoutTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
+    render(
+      <TagManager
+        task={mockTaskWithoutTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
     const input = screen.getByPlaceholderText('Add a tag...');
     const addButton = screen.getByRole('button', { name: 'Add Tag' });
 
     await userEvent.type(input, 'ErrorTag');
     await userEvent.click(addButton);
 
-    expect(await screen.findByText('Server error adding tag')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Server error adding tag'),
+    ).toBeInTheDocument();
   });
 
   it('shows error message if removing a tag fails', async () => {
     server.use(
       http.delete('/api/tasks/:taskId/tags/:tagId', () => {
-        return HttpResponse.json({ message: 'Server error removing tag' }, { status: 500 });
-      })
+        return HttpResponse.json(
+          { message: 'Server error removing tag' },
+          { status: 500 },
+        );
+      }),
     );
-    render(<TagManager task={mockTaskWithTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
+    render(
+      <TagManager
+        task={mockTaskWithTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
     const removeButtons = screen.getAllByRole('button', { name: /Remove tag/ });
-    
+
     await userEvent.click(removeButtons[0]);
 
-    expect(await screen.findByText('Server error removing tag')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Server error removing tag'),
+    ).toBeInTheDocument();
   });
 
   // Add data-testid to datalist in TagManager.jsx for this test to pass more reliably.
   // In TagManager.jsx: <datalist id="all-tags-datalist" data-testid="all-tags-datalist">
   it('renders datalist options if allTags are loaded', async () => {
-    render(<TagManager task={mockTaskWithoutTags} onTaskTagsUpdated={mockOnTaskTagsUpdated} />);
+    render(
+      <TagManager
+        task={mockTaskWithoutTags}
+        onTaskTagsUpdated={mockOnTaskTagsUpdated}
+      />,
+    );
     // Wait for tags to load (MSW will provide them)
     await waitFor(() => {
-        // This assumes you've added data-testid="all-tags-datalist" to your <datalist>
-        screen.getByTestId('all-tags-datalist'); 
-        // JSDOM doesn't fully support datalist options inspection easily.
-        // We can check if the input has the list attribute.
-        expect(screen.getByPlaceholderText('Add a tag...')).toHaveAttribute('list', 'all-tags-datalist');
-        // And check if the mocked tags are available (though not directly from datalist options in test)
-        // This part is more of an integration check that fetchAllTags was called.
+      // This assumes you've added data-testid="all-tags-datalist" to your <datalist>
+      screen.getByTestId('all-tags-datalist');
+      // JSDOM doesn't fully support datalist options inspection easily.
+      // We can check if the input has the list attribute.
+      expect(screen.getByPlaceholderText('Add a tag...')).toHaveAttribute(
+        'list',
+        'all-tags-datalist',
+      );
+      // And check if the mocked tags are available (though not directly from datalist options in test)
+      // This part is more of an integration check that fetchAllTags was called.
     });
   });
 });

--- a/frontend/src/components/__tests__/TaskCard.test.jsx
+++ b/frontend/src/components/__tests__/TaskCard.test.jsx
@@ -25,7 +25,9 @@ describe('TaskCard', () => {
 
   it('renders assignee if present', () => {
     render(<TaskCard task={mockTaskBase} onEditTask={mockOnEditTask} />);
-    expect(screen.getByText(`Assignee: ${mockTaskBase.assignee}`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`Assignee: ${mockTaskBase.assignee}`),
+    ).toBeInTheDocument();
   });
 
   it('does not render assignee if not present', () => {
@@ -38,9 +40,14 @@ describe('TaskCard', () => {
     render(<TaskCard task={mockTaskBase} onEditTask={mockOnEditTask} />);
     // Default toLocaleDateString format might vary. Check for parts.
     // e.g., "Dec 31, 2023" or "31 Dec 2023"
-    const expectedDate = new Date(mockTaskBase.due_date).toLocaleDateString(undefined, { 
-      year: 'numeric', month: 'short', day: 'numeric' 
-    });
+    const expectedDate = new Date(mockTaskBase.due_date).toLocaleDateString(
+      undefined,
+      {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      },
+    );
     expect(screen.getByText(`Due: ${expectedDate}`)).toBeInTheDocument();
   });
 
@@ -49,17 +56,23 @@ describe('TaskCard', () => {
     render(<TaskCard task={taskWithoutDueDate} onEditTask={mockOnEditTask} />);
     expect(screen.getByText('Due: Not set')).toBeInTheDocument();
   });
-  
+
   it('renders "Due: Invalid date" if due date is invalid', () => {
-    const taskWithInvalidDueDate = { ...mockTaskBase, due_date: 'invalid-date' };
-    render(<TaskCard task={taskWithInvalidDueDate} onEditTask={mockOnEditTask} />);
+    const taskWithInvalidDueDate = {
+      ...mockTaskBase,
+      due_date: 'invalid-date',
+    };
+    render(
+      <TaskCard task={taskWithInvalidDueDate} onEditTask={mockOnEditTask} />,
+    );
     expect(screen.getByText('Due: Invalid date')).toBeInTheDocument();
   });
 
-
   it('renders priority with specific style', () => {
     render(<TaskCard task={mockTaskBase} onEditTask={mockOnEditTask} />);
-    const priorityElement = screen.getByText(`Priority: ${mockTaskBase.priority}`);
+    const priorityElement = screen.getByText(
+      `Priority: ${mockTaskBase.priority}`,
+    );
     expect(priorityElement).toBeInTheDocument();
     // Check for style - this is a bit implementation-dependent.
     // The component uses inline styles: color: priorityColors[task.priority]
@@ -88,8 +101,8 @@ describe('TaskCard', () => {
     // A more robust way might be to check for absence of any tag-like elements.
     const tagsContainer = screen.queryByText('Urgent')?.closest('div'); // find an element and go up
     if (tagsContainer && tagsContainer.innerHTML.includes('Urgent')) {
-        // This means the tag was found, which is not what we want.
-        // However, the queryByText('Urgent') itself would return null.
+      // This means the tag was found, which is not what we want.
+      // However, the queryByText('Urgent') itself would return null.
     }
     expect(screen.queryByText('Urgent')).not.toBeInTheDocument();
   });

--- a/frontend/src/components/__tests__/TaskList.test.jsx
+++ b/frontend/src/components/__tests__/TaskList.test.jsx
@@ -16,7 +16,13 @@ vi.mock('../TaskCard', () => ({
 describe('TaskList', () => {
   const mockTasks = [
     { id: 1, content: 'Task One', due_date: null, priority: 'Low', tags: [] },
-    { id: 2, content: 'Task Two', due_date: '2023-01-01T00:00:00Z', priority: 'High', tags: [{id: 1, name: "Test"}] },
+    {
+      id: 2,
+      content: 'Task Two',
+      due_date: '2023-01-01T00:00:00Z',
+      priority: 'High',
+      tags: [{ id: 1, name: 'Test' }],
+    },
   ];
   const mockOnEditTask = vi.fn();
 
@@ -27,7 +33,7 @@ describe('TaskList', () => {
 
   it('renders a list of TaskCard components when tasks are provided', () => {
     render(<TaskList tasks={mockTasks} onEditTask={mockOnEditTask} />);
-    
+
     const taskCards = screen.getAllByTestId('task-card');
     expect(taskCards).toHaveLength(mockTasks.length);
     expect(taskCards[0]).toHaveTextContent('Task One');
@@ -36,11 +42,11 @@ describe('TaskList', () => {
 
   it('passes correct props to TaskCard components', () => {
     render(<TaskList tasks={mockTasks} onEditTask={mockOnEditTask} />);
-    
+
     const taskCards = screen.getAllByTestId('task-card');
     // Simulate a click on the first mocked TaskCard to check if onEditTask is called correctly
     // This relies on the mock implementation detail of TaskCard having an onClick.
-    taskCards[0].click(); 
+    taskCards[0].click();
     expect(mockOnEditTask).toHaveBeenCalledWith(mockTasks[0]);
 
     taskCards[1].click();

--- a/frontend/src/components/forms/Button.jsx
+++ b/frontend/src/components/forms/Button.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 
-const Button = ({ children, onClick, type = 'button', disabled = false, variant = 'primary', ...props }) => {
+const Button = ({
+  children,
+  onClick,
+  type = 'button',
+  disabled = false,
+  variant = 'primary',
+  ...props
+}) => {
   // Basic styling, can be expanded with different variants (primary, secondary, etc.)
   const baseStyle = {
     padding: '0.75rem 1.5rem',
@@ -27,7 +34,7 @@ const Button = ({ children, onClick, type = 'button', disabled = false, variant 
     danger: {
       backgroundColor: '#dc3545',
       color: 'white',
-    }
+    },
     // Add more variants as needed
   };
 

--- a/frontend/src/components/forms/Input.jsx
+++ b/frontend/src/components/forms/Input.jsx
@@ -1,9 +1,25 @@
 import React from 'react';
 
-const Input = ({ label, type = 'text', name, value, onChange, placeholder, required = false, ...props }) => {
+const Input = ({
+  label,
+  type = 'text',
+  name,
+  value,
+  onChange,
+  placeholder,
+  required = false,
+  ...props
+}) => {
   return (
     <div style={{ marginBottom: '1rem' }}>
-      {label && <label htmlFor={name} style={{ display: 'block', marginBottom: '0.25rem' }}>{label}</label>}
+      {label && (
+        <label
+          htmlFor={name}
+          style={{ display: 'block', marginBottom: '0.25rem' }}
+        >
+          {label}
+        </label>
+      )}
       <input
         type={type}
         id={name}

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -5,7 +5,9 @@ export const AuthContext = createContext(null);
 
 export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(localStorage.getItem('accessToken'));
-  const [isAuthenticated, setIsAuthenticated] = useState(!!localStorage.getItem('accessToken'));
+  const [isAuthenticated, setIsAuthenticated] = useState(
+    !!localStorage.getItem('accessToken'),
+  );
   // const [user, setUser] = useState(null); // Placeholder for user data
 
   useEffect(() => {
@@ -13,7 +15,8 @@ export const AuthProvider = ({ children }) => {
     if (storedToken) {
       setToken(storedToken);
       setIsAuthenticated(true);
-      apiClient.defaults.headers.common['Authorization'] = `Bearer ${storedToken}`;
+      apiClient.defaults.headers.common['Authorization'] =
+        `Bearer ${storedToken}`;
       // Optionally decode token or fetch user data here
       // e.g., const decoded = jwtDecode(storedToken); setUser(decoded);
     } else {
@@ -47,19 +50,20 @@ export const AuthProvider = ({ children }) => {
     // eslint-disable-next-line no-unused-vars
     email,
     // eslint-disable-next-line no-unused-vars
-    password
+    password,
   ) => {
     // This function might not be strictly necessary in AuthContext
     // if RegisterPage handles the API call and redirects.
     // However, it could be here if context needs to manage some part of registration flow.
     // For now, let it be a conceptual placeholder.
-    console.log("Register function in AuthContext called (conceptual)");
+    console.log('Register function in AuthContext called (conceptual)');
     // Example: return apiClient.post('/auth/register', { username, email, password });
   };
 
-
   return (
-    <AuthContext.Provider value={{ isAuthenticated, token, login, logout, register /*, user */ }}>
+    <AuthContext.Provider
+      value={{ isAuthenticated, token, login, logout, register /*, user */ }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,14 +1,23 @@
 /* Reset some default browser styles */
-body, h1, h2, h3, h4, h5, h6, p, ol, ul {
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ol,
+ul {
   margin: 0;
   padding: 0;
   font-weight: normal;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   line-height: 1.5;
@@ -17,7 +26,9 @@ body {
 }
 
 /* Use border-box sizing for all elements */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,7 +1,7 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.jsx';
 import { AuthProvider } from './contexts/AuthContext'; // Import AuthProvider
 
 createRoot(document.getElementById('root')).render(
@@ -10,4 +10,4 @@ createRoot(document.getElementById('root')).render(
       <App />
     </AuthProvider>
   </StrictMode>,
-)
+);

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -10,7 +10,10 @@ export const handlers = [
     if (email === 'test@example.com') {
       return HttpResponse.json({ access_token: 'mocked_access_token' });
     } else if (email === 'fail@example.com') {
-        return HttpResponse.json({ message: 'Invalid email or password' }, { status: 401 });
+      return HttpResponse.json(
+        { message: 'Invalid email or password' },
+        { status: 401 },
+      );
     }
     return HttpResponse.json({ message: 'User not found' }, { status: 404 });
   }),
@@ -19,16 +22,34 @@ export const handlers = [
   http.post(`${API_BASE_URL}/auth/register`, async ({ request }) => {
     const { email } = await request.json();
     if (email === 'existing@example.com') {
-      return HttpResponse.json({ message: 'Email already exists' }, { status: 409 });
+      return HttpResponse.json(
+        { message: 'Email already exists' },
+        { status: 409 },
+      );
     }
-    return HttpResponse.json({ message: 'User registered successfully' }, { status: 201 });
+    return HttpResponse.json(
+      { message: 'User registered successfully' },
+      { status: 201 },
+    );
   }),
-  
+
   // Mock for fetching projects on HomePage
   http.get(`${API_BASE_URL}/projects`, () => {
     return HttpResponse.json([
-      { id: 1, name: 'Project Alpha', description: 'Description for Alpha', created_at: new Date().toISOString(), stages: [] },
-      { id: 2, name: 'Project Beta', description: 'Description for Beta', created_at: new Date().toISOString(), stages: [] },
+      {
+        id: 1,
+        name: 'Project Alpha',
+        description: 'Description for Alpha',
+        created_at: new Date().toISOString(),
+        stages: [],
+      },
+      {
+        id: 2,
+        name: 'Project Beta',
+        description: 'Description for Beta',
+        created_at: new Date().toISOString(),
+        stages: [],
+      },
     ]);
   }),
 
@@ -43,43 +64,84 @@ export const handlers = [
         description: 'Description for Alpha',
         created_at: new Date().toISOString(),
         stages: [
-          { 
-            id: 1, name: 'To Do', project_id: 1, order: 0, created_at: new Date().toISOString(), 
+          {
+            id: 1,
+            name: 'To Do',
+            project_id: 1,
+            order: 0,
+            created_at: new Date().toISOString(),
             tasks: [
-              { id: 1, content: 'Task 1 for Alpha', stage_id: 1, due_date: null, priority: 'Medium', order: 0, tags: [{id: 1, name: "Urgent"}] },
-              { id: 2, content: 'Task 2 for Alpha', stage_id: 1, due_date: '2023-12-31T00:00:00.000Z', priority: 'High', order: 1, tags: [] },
-            ]
+              {
+                id: 1,
+                content: 'Task 1 for Alpha',
+                stage_id: 1,
+                due_date: null,
+                priority: 'Medium',
+                order: 0,
+                tags: [{ id: 1, name: 'Urgent' }],
+              },
+              {
+                id: 2,
+                content: 'Task 2 for Alpha',
+                stage_id: 1,
+                due_date: '2023-12-31T00:00:00.000Z',
+                priority: 'High',
+                order: 1,
+                tags: [],
+              },
+            ],
           },
-          { 
-            id: 2, name: 'In Progress', project_id: 1, order: 1, created_at: new Date().toISOString(),
+          {
+            id: 2,
+            name: 'In Progress',
+            project_id: 1,
+            order: 1,
+            created_at: new Date().toISOString(),
             tasks: [
-              { id: 3, content: 'Task 3 for Alpha', stage_id: 2, due_date: '2024-01-15T00:00:00.000Z', priority: 'Low', order: 0, tags: [] },
-            ]
+              {
+                id: 3,
+                content: 'Task 3 for Alpha',
+                stage_id: 2,
+                due_date: '2024-01-15T00:00:00.000Z',
+                priority: 'Low',
+                order: 0,
+                tags: [],
+              },
+            ],
           },
         ],
       });
     }
     if (projectId === 'project-error') {
-        return HttpResponse.json({ message: 'Failed to fetch project (mocked error)' }, { status: 500 });
+      return HttpResponse.json(
+        { message: 'Failed to fetch project (mocked error)' },
+        { status: 500 },
+      );
     }
     return HttpResponse.json({ message: 'Project not found' }, { status: 404 });
   }),
 
   // Mock for creating a task
-  http.post(`${API_BASE_URL}/stages/:stageId/tasks`, async ({ request, params }) => {
-    const { stageId } = params;
-    const taskData = await request.json();
-    return HttpResponse.json({
-      id: Date.now(), // Mock new task ID
-      stage_id: parseInt(stageId),
-      ...taskData,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      tags: [], // New tasks usually have no tags initially
-      subtasks: [],
-    }, { status: 201 });
-  }),
-  
+  http.post(
+    `${API_BASE_URL}/stages/:stageId/tasks`,
+    async ({ request, params }) => {
+      const { stageId } = params;
+      const taskData = await request.json();
+      return HttpResponse.json(
+        {
+          id: Date.now(), // Mock new task ID
+          stage_id: parseInt(stageId),
+          ...taskData,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          tags: [], // New tasks usually have no tags initially
+          subtasks: [],
+        },
+        { status: 201 },
+      );
+    },
+  ),
+
   // Mock for updating a task
   http.put(`${API_BASE_URL}/tasks/:taskId`, async ({ request, params }) => {
     const { taskId } = params;
@@ -94,76 +156,125 @@ export const handlers = [
   // Mock for fetching comments
   http.get(`${API_BASE_URL}/tasks/:taskId/comments`, ({ params }) => {
     const { taskId } = params;
-    if (taskId === '1') { // Task 1 has comments
-        return HttpResponse.json([
-            { id: 1, content: 'First comment on task 1', task_id: 1, user_id: 1, commenter_username: 'UserAlpha', created_at: new Date().toISOString() },
-            { id: 2, content: 'Second comment on task 1', task_id: 1, user_id: 2, commenter_username: 'UserBeta', created_at: new Date().toISOString() },
-        ]);
+    if (taskId === '1') {
+      // Task 1 has comments
+      return HttpResponse.json([
+        {
+          id: 1,
+          content: 'First comment on task 1',
+          task_id: 1,
+          user_id: 1,
+          commenter_username: 'UserAlpha',
+          created_at: new Date().toISOString(),
+        },
+        {
+          id: 2,
+          content: 'Second comment on task 1',
+          task_id: 1,
+          user_id: 2,
+          commenter_username: 'UserBeta',
+          created_at: new Date().toISOString(),
+        },
+      ]);
     }
     return HttpResponse.json([]); // Default to no comments
   }),
 
   // Mock for adding a comment
-  http.post(`${API_BASE_URL}/tasks/:taskId/comments`, async ({ request, params }) => {
-    const { taskId } = params;
-    const { content } = await request.json();
-    // Assume user_id 1 and username 'CurrentUser' for simplicity in mock
-    return HttpResponse.json({ 
-        id: Date.now(), 
-        content, 
-        task_id: parseInt(taskId), 
-        user_id: 1, 
-        commenter_username: 'CurrentUser', 
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-    }, { status: 201 });
-  }),
+  http.post(
+    `${API_BASE_URL}/tasks/:taskId/comments`,
+    async ({ request, params }) => {
+      const { taskId } = params;
+      const { content } = await request.json();
+      // Assume user_id 1 and username 'CurrentUser' for simplicity in mock
+      return HttpResponse.json(
+        {
+          id: Date.now(),
+          content,
+          task_id: parseInt(taskId),
+          user_id: 1,
+          commenter_username: 'CurrentUser',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        { status: 201 },
+      );
+    },
+  ),
 
   // Mock for fetching task activities
   http.get(`${API_BASE_URL}/tasks/:taskId/activities`, ({ params }) => {
     const { taskId } = params;
     return HttpResponse.json([
-        { id: 1, action_type: 'TASK_CREATED', description: `Task ${taskId} created by TestUser`, user_id: 1, user_username: 'TestUser', task_id: parseInt(taskId), created_at: new Date().toISOString() },
-        { id: 2, action_type: 'COMMENT_ADDED', description: `TestUser commented on Task ${taskId}`, user_id: 1, user_username: 'TestUser', task_id: parseInt(taskId), created_at: new Date().toISOString() },
+      {
+        id: 1,
+        action_type: 'TASK_CREATED',
+        description: `Task ${taskId} created by TestUser`,
+        user_id: 1,
+        user_username: 'TestUser',
+        task_id: parseInt(taskId),
+        created_at: new Date().toISOString(),
+      },
+      {
+        id: 2,
+        action_type: 'COMMENT_ADDED',
+        description: `TestUser commented on Task ${taskId}`,
+        user_id: 1,
+        user_username: 'TestUser',
+        task_id: parseInt(taskId),
+        created_at: new Date().toISOString(),
+      },
     ]);
   }),
 
   // Mock for fetching project activities
   http.get(`${API_BASE_URL}/projects/:projectId/activities`, ({ params }) => {
     const { projectId } = params;
-     return HttpResponse.json([
-        { id: 1, action_type: 'PROJECT_CREATED', description: `Project ${projectId} created by TestUser`, user_id: 1, user_username: 'TestUser', project_id: parseInt(projectId), created_at: new Date().toISOString() },
+    return HttpResponse.json([
+      {
+        id: 1,
+        action_type: 'PROJECT_CREATED',
+        description: `Project ${projectId} created by TestUser`,
+        user_id: 1,
+        user_username: 'TestUser',
+        project_id: parseInt(projectId),
+        created_at: new Date().toISOString(),
+      },
     ]);
   }),
 
   // Mock for fetching all tags
   http.get(`${API_BASE_URL}/tags`, () => {
     return HttpResponse.json([
-        { id: 1, name: 'Urgent' },
-        { id: 2, name: 'Backend' },
-        { id: 3, name: 'Frontend' },
+      { id: 1, name: 'Urgent' },
+      { id: 2, name: 'Backend' },
+      { id: 3, name: 'Frontend' },
     ]);
   }),
 
   // Mock for adding a tag to a task
-  http.post(`${API_BASE_URL}/tasks/:taskId/tags`, async ({ request, params }) => {
-    const { taskId } = params;
-    const { tag_name, tag_id } = await request.json();
-    // This mock needs to return the full task object with updated tags
-    // For simplicity, we'll just return a success message or a simplified task
-    // A more complete mock would fetch the task, add the tag, then return it.
-    let newTag;
-    if (tag_id) newTag = { id: tag_id, name: "ExistingTagNameMock" }; // Assume it exists
-    else newTag = { id: Date.now(), name: tag_name };
-    
-    // This should ideally return the full task object with all its properties and the *updated* tags array.
-    // For now, just echo back something simple. Test will need to mock this more specifically if needed.
-    return HttpResponse.json({
+  http.post(
+    `${API_BASE_URL}/tasks/:taskId/tags`,
+    async ({ request, params }) => {
+      const { taskId } = params;
+      const { tag_name, tag_id } = await request.json();
+      // This mock needs to return the full task object with updated tags
+      // For simplicity, we'll just return a success message or a simplified task
+      // A more complete mock would fetch the task, add the tag, then return it.
+      let newTag;
+      if (tag_id)
+        newTag = { id: tag_id, name: 'ExistingTagNameMock' }; // Assume it exists
+      else newTag = { id: Date.now(), name: tag_name };
+
+      // This should ideally return the full task object with all its properties and the *updated* tags array.
+      // For now, just echo back something simple. Test will need to mock this more specifically if needed.
+      return HttpResponse.json({
         id: parseInt(taskId),
-        content: "Mocked task content after tag add",
-        tags: [newTag] // This is simplified; should be list of all tags on task
-    });
-  }),
+        content: 'Mocked task content after tag add',
+        tags: [newTag], // This is simplified; should be list of all tags on task
+      });
+    },
+  ),
 
   // Mock for removing a tag from a task
   http.delete(`${API_BASE_URL}/tasks/:taskId/tags/:tagId`, () => {
@@ -173,14 +284,17 @@ export const handlers = [
   // Mock for creating a project
   http.post(`${API_BASE_URL}/projects`, async ({ request }) => {
     const data = await request.json();
-    return HttpResponse.json({
-      id: Date.now(), // Mock new project ID
-      ...data,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      stages: [],
-      user_id: 1 // Mock user ID
-    }, { status: 201 });
+    return HttpResponse.json(
+      {
+        id: Date.now(), // Mock new project ID
+        ...data,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        stages: [],
+        user_id: 1, // Mock user ID
+      },
+      { status: 201 },
+    );
   }),
 
   // Add other handlers as needed...

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -49,7 +49,10 @@
   list-style-type: none;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); /* Responsive grid */
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(300px, 1fr)
+  ); /* Responsive grid */
   gap: 20px;
 }
 
@@ -57,12 +60,12 @@
   background-color: #fff;
   border: 1px solid #ddd;
   border-radius: 6px;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
   transition: box-shadow 0.2s ease-in-out;
 }
 
 .project-list-item:hover {
-  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }
 
 .project-link {
@@ -110,7 +113,7 @@
   background: white;
   padding: 25px;
   border-radius: 8px;
-  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
   width: 90%;
   /* max-width: 500px; (Adjusted in HomePage.jsx for project modal) */
   display: flex;
@@ -136,8 +139,8 @@
   color: #555;
 }
 
-.form-group input[type="text"],
-.form-group input[type="date"],
+.form-group input[type='text'],
+.form-group input[type='date'],
 .form-group textarea,
 .form-group select {
   width: 100%;
@@ -166,7 +169,9 @@
   cursor: pointer;
   font-size: 1em;
   font-weight: bold;
-  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .modal-actions .button-cancel {
@@ -186,5 +191,5 @@
 
 .modal-actions .button-save:hover {
   background-color: #0056b3;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -11,7 +11,6 @@ const HomePage = () => {
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectDescription, setNewProjectDescription] = useState('');
 
-
   const fetchProjects = async () => {
     setLoading(true);
     try {
@@ -33,26 +32,27 @@ const HomePage = () => {
   const handleCreateProject = async (e) => {
     e.preventDefault();
     if (!newProjectName.trim()) {
-        alert("Project name cannot be empty.");
-        return;
+      alert('Project name cannot be empty.');
+      return;
     }
     try {
-        await apiClient.post('/projects', { 
-            name: newProjectName, 
-            description: newProjectDescription 
-        });
-        // Add new project to the list locally or re-fetch
-        // setProjects(prevProjects => [...prevProjects, response.data]); 
-        fetchProjects(); // Re-fetch to get the latest list including the new one
-        setIsCreateModalOpen(false);
-        setNewProjectName('');
-        setNewProjectDescription('');
+      await apiClient.post('/projects', {
+        name: newProjectName,
+        description: newProjectDescription,
+      });
+      // Add new project to the list locally or re-fetch
+      // setProjects(prevProjects => [...prevProjects, response.data]);
+      fetchProjects(); // Re-fetch to get the latest list including the new one
+      setIsCreateModalOpen(false);
+      setNewProjectName('');
+      setNewProjectDescription('');
     } catch (err) {
-        console.error("Failed to create project:", err);
-        alert(`Error: ${err.response?.data?.message || 'Could not create project.'}`);
+      console.error('Failed to create project:', err);
+      alert(
+        `Error: ${err.response?.data?.message || 'Could not create project.'}`,
+      );
     }
   };
-
 
   if (loading) return <p className="loading-message">Loading projects...</p>;
   if (error) return <p className="error-message">{error}</p>;
@@ -61,7 +61,10 @@ const HomePage = () => {
     <div className="home-page-container">
       <div className="home-page-header">
         <h2>Your Projects</h2>
-        <button onClick={() => setIsCreateModalOpen(true)} className="create-project-button">
+        <button
+          onClick={() => setIsCreateModalOpen(true)}
+          className="create-project-button"
+        >
           + Create New Project
         </button>
       </div>
@@ -70,11 +73,13 @@ const HomePage = () => {
         <p>No projects found. Get started by creating one!</p>
       ) : (
         <ul className="project-list">
-          {projects.map(project => (
+          {projects.map((project) => (
             <li key={project.id} className="project-list-item">
               <Link to={`/project/${project.id}`} className="project-link">
                 <h3 className="project-name">{project.name}</h3>
-                <p className="project-description">{project.description || 'No description'}</p>
+                <p className="project-description">
+                  {project.description || 'No description'}
+                </p>
                 <span className="project-created-at">
                   Created: {new Date(project.created_at).toLocaleDateString()}
                 </span>
@@ -85,8 +90,10 @@ const HomePage = () => {
       )}
 
       {isCreateModalOpen && (
-        <div className="modal-overlay"> {/* Reusing modal styles concept from TaskModal */}
-          <div className="modal-content" style={{maxWidth: '400px'}}>
+        <div className="modal-overlay">
+          {' '}
+          {/* Reusing modal styles concept from TaskModal */}
+          <div className="modal-content" style={{ maxWidth: '400px' }}>
             <h3>Create New Project</h3>
             <form onSubmit={handleCreateProject}>
               <div className="form-group">
@@ -100,7 +107,9 @@ const HomePage = () => {
                 />
               </div>
               <div className="form-group">
-                <label htmlFor="project-description">Description (Optional):</label>
+                <label htmlFor="project-description">
+                  Description (Optional):
+                </label>
                 <textarea
                   id="project-description"
                   value={newProjectDescription}
@@ -109,7 +118,11 @@ const HomePage = () => {
                 />
               </div>
               <div className="modal-actions">
-                <button type="button" onClick={() => setIsCreateModalOpen(false)} className="button-cancel">
+                <button
+                  type="button"
+                  onClick={() => setIsCreateModalOpen(false)}
+                  className="button-cancel"
+                >
                   Cancel
                 </button>
                 <button type="submit" className="button-save">

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -28,12 +28,13 @@ const LoginPage = () => {
 
       const { access_token } = response.data;
       localStorage.setItem('accessToken', access_token); // Store token
-      
+
       // Here, you would typically update the AuthContext
       // For now, directly navigating.
       // if (contextLogin) contextLogin(access_token); // Call context login function
 
-      apiClient.defaults.headers.common['Authorization'] = `Bearer ${access_token}`; // Set for current session
+      apiClient.defaults.headers.common['Authorization'] =
+        `Bearer ${access_token}`; // Set for current session
 
       navigate('/'); // Redirect to home/dashboard
     } catch (err) {
@@ -46,7 +47,15 @@ const LoginPage = () => {
   };
 
   return (
-    <div style={{ maxWidth: '400px', margin: '2rem auto', padding: '2rem', border: '1px solid #eee', borderRadius: '8px' }}>
+    <div
+      style={{
+        maxWidth: '400px',
+        margin: '2rem auto',
+        padding: '2rem',
+        border: '1px solid #eee',
+        borderRadius: '8px',
+      }}
+    >
       <h2>Login</h2>
       {error && <p style={{ color: 'red' }}>{error}</p>}
       <form onSubmit={handleSubmit}>

--- a/frontend/src/pages/ProjectViewPage.css
+++ b/frontend/src/pages/ProjectViewPage.css
@@ -33,7 +33,9 @@
   color: #5e6c84; /* Default tab color */
   border-bottom: 3px solid transparent;
   margin-right: 15px;
-  transition: color 0.2s ease, border-bottom-color 0.2s ease;
+  transition:
+    color 0.2s ease,
+    border-bottom-color 0.2s ease;
 }
 
 .project-view-tabs button:hover {
@@ -46,13 +48,12 @@
   font-weight: 600; /* Bolder for active tab */
 }
 
-
 .stages-container {
   display: flex;
-  flex-direction: row; 
-  overflow-x: auto; 
-  padding: 0 10px 20px 10px; 
-  align-items: flex-start; 
+  flex-direction: row;
+  overflow-x: auto;
+  padding: 0 10px 20px 10px;
+  align-items: flex-start;
   min-height: calc(100vh - 250px); /* Adjusted for header and tabs */
 }
 
@@ -71,12 +72,13 @@
 /* Styling for loading/error messages on this page */
 .project-view-loading,
 .project-view-error,
-.project-view-message { /* For "Project not found" etc. */
+.project-view-message {
+  /* For "Project not found" etc. */
   padding: 20px;
   text-align: center;
   font-size: 1.2em;
 }
 
 .project-view-error {
-  color: #de350b; 
+  color: #de350b;
 }

--- a/frontend/src/pages/ProjectViewPage.jsx
+++ b/frontend/src/pages/ProjectViewPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import apiClient from '../services/api';
-import StageColumn from '../components/StageColumn'; 
+import StageColumn from '../components/StageColumn';
 import TaskModal from '../components/TaskModal';
 import ActivityLogList from '../components/ActivityLogList'; // Import ActivityLogList
 import './ProjectViewPage.css';
@@ -18,11 +18,12 @@ const ProjectViewPage = () => {
 
   // Tab state for ProjectViewPage content (e.g., 'board' or 'activity')
 
-
   const fetchProjectData = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await apiClient.get(`/projects/${projectId}?include_stages=true&include_tasks=true`);
+      const response = await apiClient.get(
+        `/projects/${projectId}?include_stages=true&include_tasks=true`,
+      );
       setProject(response.data);
       setError(null);
     } catch (err) {
@@ -57,21 +58,22 @@ const ProjectViewPage = () => {
 
   const handleSaveTask = async (taskData) => {
     try {
-      if (editingTask && editingTask.id) { // Editing existing task
+      if (editingTask && editingTask.id) {
+        // Editing existing task
         // If stage_id is part of taskData and different, backend handles move
         await apiClient.put(`/tasks/${editingTask.id}`, taskData);
-      } else { // Creating new task
+      } else {
+        // Creating new task
         await apiClient.post(`/stages/${currentStageId}/tasks`, taskData);
       }
       fetchProjectData(); // Re-fetch all data to reflect changes
       handleCloseModal();
     } catch (err) {
-      console.error("Failed to save task:", err);
+      console.error('Failed to save task:', err);
       alert(`Error: ${err.response?.data?.message || 'Could not save task.'}`);
       // Keep modal open for correction if preferred
     }
   };
-
 
   if (loading) return <p>Loading project...</p>;
   if (error) return <p style={{ color: 'red' }}>{error}</p>;
@@ -82,9 +84,9 @@ const ProjectViewPage = () => {
       <h2>{project.name}</h2>
       <p>{project.description}</p>
       <div style={{ display: 'flex', overflowX: 'auto' }}>
-        {(project?.stages || []).map(stage => (
-          <StageColumn 
-            key={stage.id} 
+        {(project?.stages || []).map((stage) => (
+          <StageColumn
+            key={stage.id}
             stage={stage}
             onAddTask={handleOpenModalForCreate}
             onEditTask={handleOpenModalForEdit}
@@ -92,13 +94,13 @@ const ProjectViewPage = () => {
         ))}
         {/* Potentially a button to add a new stage here */}
       </div>
-      
+
       <TaskModal
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         onSave={handleSaveTask}
         task={editingTask}
-        stageId={currentStageId} 
+        stageId={currentStageId}
       />
     </div>
   );

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -33,7 +33,7 @@ const RegisterPage = () => {
       setUsername('');
       setEmail('');
       setPassword('');
-      
+
       setTimeout(() => {
         navigate('/login');
       }, 2000); // Redirect after 2 seconds
@@ -47,7 +47,15 @@ const RegisterPage = () => {
   };
 
   return (
-    <div style={{ maxWidth: '400px', margin: '2rem auto', padding: '2rem', border: '1px solid #eee', borderRadius: '8px' }}>
+    <div
+      style={{
+        maxWidth: '400px',
+        margin: '2rem auto',
+        padding: '2rem',
+        border: '1px solid #eee',
+        borderRadius: '8px',
+      }}
+    >
       <h2>Register</h2>
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {successMessage && <p style={{ color: 'green' }}>{successMessage}</p>}

--- a/frontend/src/pages/__tests__/LoginPage.test.jsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.jsx
@@ -21,10 +21,12 @@ vi.mock('react-router-dom', async () => {
 const renderLoginPage = () => {
   return render(
     <MemoryRouter>
-      <AuthProvider> {/* LoginPage uses AuthContext.login */}
+      <AuthProvider>
+        {' '}
+        {/* LoginPage uses AuthContext.login */}
         <LoginPage />
       </AuthProvider>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 };
 
@@ -39,8 +41,11 @@ describe('LoginPage', () => {
         if (email === 'test@example.com') {
           return HttpResponse.json({ access_token: 'mock_token' });
         }
-        return HttpResponse.json({ message: 'Invalid credentials' }, { status: 401 });
-      })
+        return HttpResponse.json(
+          { message: 'Invalid credentials' },
+          { status: 401 },
+        );
+      }),
     );
   });
 
@@ -65,9 +70,9 @@ describe('LoginPage', () => {
     // AuthContext.login is called internally by LoginPage's handleSubmit
     // We can spy on localStorage.setItem to confirm token storage
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
-    
+
     renderLoginPage();
-    
+
     await userEvent.type(screen.getByLabelText('Email:'), 'test@example.com');
     await userEvent.type(screen.getByLabelText('Password:'), 'password123');
     await userEvent.click(screen.getByRole('button', { name: 'Login' }));
@@ -84,8 +89,11 @@ describe('LoginPage', () => {
   it('displays error message on failed login (e.g. invalid credentials)', async () => {
     server.use(
       http.post('/api/auth/login', () => {
-        return HttpResponse.json({ message: 'Invalid email or password' }, { status: 401 });
-      })
+        return HttpResponse.json(
+          { message: 'Invalid email or password' },
+          { status: 401 },
+        );
+      }),
     );
     renderLoginPage();
 
@@ -93,29 +101,33 @@ describe('LoginPage', () => {
     await userEvent.type(screen.getByLabelText('Password:'), 'wrongpassword');
     await userEvent.click(screen.getByRole('button', { name: 'Login' }));
 
-    expect(await screen.findByText('Login failed: Invalid email or password')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Login failed: Invalid email or password'),
+    ).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('displays error message if API returns non-JSON error or network error', async () => {
     server.use(
       http.post('/api/auth/login', () => {
-        return new HttpResponse("Server Error", { status: 500 });
-      })
+        return new HttpResponse('Server Error', { status: 500 });
+      }),
     );
     renderLoginPage();
 
     await userEvent.type(screen.getByLabelText('Email:'), 'test@example.com');
     await userEvent.type(screen.getByLabelText('Password:'), 'password');
     await userEvent.click(screen.getByRole('button', { name: 'Login' }));
-    
+
     // The error message might be generic if it's not JSON from API
-    expect(await screen.findByText(/Login failed:/)).toBeInTheDocument(); 
+    expect(await screen.findByText(/Login failed:/)).toBeInTheDocument();
   });
-  
+
   it('shows a link to the registration page', () => {
     renderLoginPage();
-    const registerLink = screen.getByRole('link', { name: "Don't have an account? Register" });
+    const registerLink = screen.getByRole('link', {
+      name: "Don't have an account? Register",
+    });
     expect(registerLink).toBeInTheDocument();
     expect(registerLink).toHaveAttribute('href', '/register');
   });

--- a/frontend/src/pages/__tests__/ProjectViewPage.test.jsx
+++ b/frontend/src/pages/__tests__/ProjectViewPage.test.jsx
@@ -9,116 +9,164 @@ import ProjectViewPage from '../ProjectViewPage';
 import { AuthProvider } from '../../contexts/AuthContext'; // Assuming ProtectedRoute needs this
 
 // Mock child components to focus on ProjectViewPage logic
-vi.mock('../../components/StageColumn', () => ({ 
-    default: ({ stage, onAddTask, onEditTask }) => (
-        <div data-testid={`stage-column-${stage.id}`}>
-            <h3>{stage.name}</h3>
-            <button onClick={() => onAddTask(stage.id)}>Add Task to {stage.name}</button>
-            {stage.tasks && stage.tasks.map(task => (
-                <div key={task.id} data-testid={`task-${task.id}`} onClick={() => onEditTask(task)}>
-                    {task.content}
-                </div>
-            ))}
-        </div>
-    )
+vi.mock('../../components/StageColumn', () => ({
+  default: ({ stage, onAddTask, onEditTask }) => (
+    <div data-testid={`stage-column-${stage.id}`}>
+      <h3>{stage.name}</h3>
+      <button onClick={() => onAddTask(stage.id)}>
+        Add Task to {stage.name}
+      </button>
+      {stage.tasks &&
+        stage.tasks.map((task) => (
+          <div
+            key={task.id}
+            data-testid={`task-${task.id}`}
+            onClick={() => onEditTask(task)}
+          >
+            {task.content}
+          </div>
+        ))}
+    </div>
+  ),
 }));
 vi.mock('../../components/TaskModal', () => ({
-    // eslint-disable-next-line no-unused-vars
-    default: ({ isOpen, onClose, onSave, task, stageId, onTaskUpdated }) => {
-        if (!isOpen) return null;
-        return (
-            <div data-testid="task-modal">
-                <h4>{task ? `Edit ${task.content}` : `New task for stage ${stageId}`}</h4>
-                <button onClick={onClose}>CloseModal</button>
-                <button onClick={() => onSave({ content: 'saved' })}>SaveModalTask</button>
-            </div>
-        );
-    }
+  // eslint-disable-next-line no-unused-vars
+  default: ({ isOpen, onClose, onSave, task, stageId, onTaskUpdated }) => {
+    if (!isOpen) return null;
+    return (
+      <div data-testid="task-modal">
+        <h4>
+          {task ? `Edit ${task.content}` : `New task for stage ${stageId}`}
+        </h4>
+        <button onClick={onClose}>CloseModal</button>
+        <button onClick={() => onSave({ content: 'saved' })}>
+          SaveModalTask
+        </button>
+      </div>
+    );
+  },
 }));
 vi.mock('../../components/ActivityLogList', () => ({
-    default: ({ activities, loading, error }) => (
-        <div data-testid="activity-log-list">
-            {loading && <p>Loading activities...</p>}
-            {error && <p>Error: {error}</p>}
-            {activities && activities.map(act => <div key={act.id}>{act.description}</div>)}
-        </div>
-    )
+  default: ({ activities, loading, error }) => (
+    <div data-testid="activity-log-list">
+      {loading && <p>Loading activities...</p>}
+      {error && <p>Error: {error}</p>}
+      {activities &&
+        activities.map((act) => <div key={act.id}>{act.description}</div>)}
+    </div>
+  ),
 }));
-
 
 const mockProjectData = {
   id: 1,
   name: 'Test Project Detailed',
   description: 'Detailed description here',
   stages: [
-    { 
-      id: 1, name: 'To Do', project_id: 1, order: 0, 
-      tasks: [{ id: 1, content: 'Task 1 in ToDo', stage_id: 1 }]
+    {
+      id: 1,
+      name: 'To Do',
+      project_id: 1,
+      order: 0,
+      tasks: [{ id: 1, content: 'Task 1 in ToDo', stage_id: 1 }],
     },
-    { 
-      id: 2, name: 'In Progress', project_id: 1, order: 1, 
-      tasks: [{ id: 2, content: 'Task 2 in Progress', stage_id: 2 }]
+    {
+      id: 2,
+      name: 'In Progress',
+      project_id: 1,
+      order: 1,
+      tasks: [{ id: 2, content: 'Task 2 in Progress', stage_id: 2 }],
     },
   ],
 };
 
 const mockProjectActivities = [
-  { id: 1, description: 'Project activity 1', created_at: new Date().toISOString() },
-  { id: 2, description: 'Project activity 2', created_at: new Date().toISOString() },
+  {
+    id: 1,
+    description: 'Project activity 1',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    description: 'Project activity 2',
+    created_at: new Date().toISOString(),
+  },
 ];
 
-const renderWithRouter = (ui, { route = '/project/1', path = '/project/:projectId' } = {}) => {
+const renderWithRouter = (
+  ui,
+  { route = '/project/1', path = '/project/:projectId' } = {},
+) => {
   window.history.pushState({}, 'Test page', route);
   return render(
-    <AuthProvider> {/* Assuming AuthProvider is needed by underlying components or context */}
+    <AuthProvider>
+      {' '}
+      {/* Assuming AuthProvider is needed by underlying components or context */}
       <MemoryRouter initialEntries={[route]}>
         <Routes>
           <Route path={path} element={ui} />
         </Routes>
       </MemoryRouter>
-    </AuthProvider>
+    </AuthProvider>,
   );
 };
-
 
 describe('ProjectViewPage', () => {
   beforeEach(() => {
     server.resetHandlers();
     server.use(
       http.get('/api/projects/1', () => HttpResponse.json(mockProjectData)),
-      http.get('/api/projects/1/activities', () => HttpResponse.json(mockProjectActivities)),
-      http.get('/api/projects/error', () => HttpResponse.json({ message: 'Server Error Fetching Project' }, { status: 500 })),
-      http.get('/api/projects/notfound', () => HttpResponse.json({ message: 'Project Not Found' }, { status: 404 }))
+      http.get('/api/projects/1/activities', () =>
+        HttpResponse.json(mockProjectActivities),
+      ),
+      http.get('/api/projects/error', () =>
+        HttpResponse.json(
+          { message: 'Server Error Fetching Project' },
+          { status: 500 },
+        ),
+      ),
+      http.get('/api/projects/notfound', () =>
+        HttpResponse.json({ message: 'Project Not Found' }, { status: 404 }),
+      ),
     );
   });
 
   it('fetches and renders project details, stages, and tasks', async () => {
     renderWithRouter(<ProjectViewPage />);
-    
-    expect(await screen.findByRole('heading', { name: 'Test Project Detailed' })).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole('heading', { name: 'Test Project Detailed' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('Detailed description here')).toBeInTheDocument();
-    
+
     // Check for stages (mocked StageColumn)
     expect(screen.getByTestId('stage-column-1')).toHaveTextContent('To Do');
-    expect(screen.getByTestId('stage-column-2')).toHaveTextContent('In Progress');
-    
+    expect(screen.getByTestId('stage-column-2')).toHaveTextContent(
+      'In Progress',
+    );
+
     // Check for tasks (mocked StageColumn rendering task content)
     expect(screen.getByTestId('task-1')).toHaveTextContent('Task 1 in ToDo');
-    expect(screen.getByTestId('task-2')).toHaveTextContent('Task 2 in Progress');
+    expect(screen.getByTestId('task-2')).toHaveTextContent(
+      'Task 2 in Progress',
+    );
   });
 
   it('displays loading state initially', () => {
     // Prevent MSW from responding immediately to see loading state
-    server.use(http.get('/api/projects/1', () => new Promise(() => {}), { once: true }));
+    server.use(
+      http.get('/api/projects/1', () => new Promise(() => {}), { once: true }),
+    );
     renderWithRouter(<ProjectViewPage />);
     expect(screen.getByText('Loading project...')).toBeInTheDocument();
   });
 
   it('displays error state if project data fetching fails', async () => {
     renderWithRouter(<ProjectViewPage />, { route: '/project/error' });
-    expect(await screen.findByText('Server Error Fetching Project')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Server Error Fetching Project'),
+    ).toBeInTheDocument();
   });
-  
+
   it('displays "Project not found" if project is not found (404)', async () => {
     renderWithRouter(<ProjectViewPage />, { route: '/project/notfound' });
     // The component itself renders "Project not found." if !project after loading.
@@ -126,13 +174,14 @@ describe('ProjectViewPage', () => {
     expect(await screen.findByText('Project Not Found')).toBeInTheDocument();
   });
 
-
   it('opens TaskModal for creating a new task', async () => {
     renderWithRouter(<ProjectViewPage />);
     await screen.findByRole('heading', { name: 'Test Project Detailed' }); // Wait for page to load
 
     // Click "Add Task" in the first stage (mocked StageColumn)
-    const addTaskButton = screen.getByRole('button', { name: 'Add Task to To Do' });
+    const addTaskButton = screen.getByRole('button', {
+      name: 'Add Task to To Do',
+    });
     await userEvent.click(addTaskButton);
 
     const taskModal = await screen.findByTestId('task-modal');
@@ -157,7 +206,9 @@ describe('ProjectViewPage', () => {
     renderWithRouter(<ProjectViewPage />);
     await screen.findByRole('heading', { name: 'Test Project Detailed' }); // Ensure page loaded
 
-    const activityTabButton = screen.getByRole('button', { name: 'Project Activity' });
+    const activityTabButton = screen.getByRole('button', {
+      name: 'Project Activity',
+    });
     await userEvent.click(activityTabButton);
 
     expect(await screen.findByText('Project Activity Log')).toBeInTheDocument();
@@ -178,7 +229,9 @@ describe('ProjectViewPage', () => {
         activityFetchCount++;
         return HttpResponse.json(mockProjectActivities);
       }),
-      http.post('/api/stages/1/tasks', async () => HttpResponse.json({ id: 99, content: 'saved' }, {status: 201}))
+      http.post('/api/stages/1/tasks', async () =>
+        HttpResponse.json({ id: 99, content: 'saved' }, { status: 201 }),
+      ),
     );
 
     renderWithRouter(<ProjectViewPage />);
@@ -187,43 +240,53 @@ describe('ProjectViewPage', () => {
     expect(activityFetchCount).toBe(1);
 
     // Open and "save" modal for new task
-    const addTaskButton = screen.getByRole('button', { name: 'Add Task to To Do' });
+    const addTaskButton = screen.getByRole('button', {
+      name: 'Add Task to To Do',
+    });
     await userEvent.click(addTaskButton);
-    
+
     await screen.findByTestId('task-modal'); // Ensure modal is present
-    const saveButtonInModal = screen.getByRole('button', { name: 'SaveModalTask' }); // From mock
+    const saveButtonInModal = screen.getByRole('button', {
+      name: 'SaveModalTask',
+    }); // From mock
     await userEvent.click(saveButtonInModal);
-    
+
     // Modal closes (mock doesn't auto-close, but onSave is called)
     // ProjectViewPage's handleSaveTask should call fetchProjectData and fetchProjectActivities
     await waitFor(() => expect(projectFetchCount).toBe(2));
     await waitFor(() => expect(activityFetchCount).toBe(2));
   });
-  
+
   it('TaskModal onTaskUpdated (e.g. after comment) refreshes project activities', async () => {
     let activityFetchCount = 0;
     server.use(
       http.get('/api/projects/1', () => HttpResponse.json(mockProjectData)), // Initial load
-      http.get('/api/projects/1/activities', () => { // Initial and refresh
+      http.get('/api/projects/1/activities', () => {
+        // Initial and refresh
         activityFetchCount++;
         return HttpResponse.json(mockProjectActivities);
-      })
+      }),
     );
     // Mock TaskModal to be able to call onTaskUpdated
-    vi.mock('../../components/TaskModal', () => ({ 
+    vi.mock('../../components/TaskModal', () => ({
       default: ({ isOpen, onClose, onSave, task, stageId, onTaskUpdated }) => {
-          if (!isOpen) return null;
-          return (
-              <div data-testid="task-modal">
-                  <h4>{task ? `Edit ${task.content}` : `New task for stage ${stageId}`}</h4>
-                  <button onClick={onClose}>CloseModal</button>
-                  <button onClick={() => onSave({ content: 'saved' })}>SaveModalTask</button>
-                  {task && <button onClick={onTaskUpdated}>TriggerTaskUpdateInModal</button>}
-              </div>
-          );
-      }
+        if (!isOpen) return null;
+        return (
+          <div data-testid="task-modal">
+            <h4>
+              {task ? `Edit ${task.content}` : `New task for stage ${stageId}`}
+            </h4>
+            <button onClick={onClose}>CloseModal</button>
+            <button onClick={() => onSave({ content: 'saved' })}>
+              SaveModalTask
+            </button>
+            {task && (
+              <button onClick={onTaskUpdated}>TriggerTaskUpdateInModal</button>
+            )}
+          </div>
+        );
+      },
     }));
-
 
     renderWithRouter(<ProjectViewPage />);
     await screen.findByRole('heading', { name: 'Test Project Detailed' });
@@ -232,12 +295,13 @@ describe('ProjectViewPage', () => {
     // Open modal for editing
     const taskElement = screen.getByTestId('task-1');
     await userEvent.click(taskElement);
-    
+
     await screen.findByTestId('task-modal'); // Ensure modal is present
-    const triggerUpdateInModalButton = screen.getByRole('button', { name: 'TriggerTaskUpdateInModal' });
+    const triggerUpdateInModalButton = screen.getByRole('button', {
+      name: 'TriggerTaskUpdateInModal',
+    });
     await userEvent.click(triggerUpdateInModalButton);
 
     await waitFor(() => expect(activityFetchCount).toBe(2)); // Should re-fetch activities
   });
-
 });

--- a/frontend/src/pages/__tests__/RegisterPage.test.jsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.jsx
@@ -21,10 +21,12 @@ vi.mock('react-router-dom', async () => {
 const renderRegisterPage = () => {
   return render(
     <MemoryRouter>
-      <AuthProvider> {/* AuthProvider might not be strictly necessary if RegisterPage doesn't use context directly, but good for consistency */}
+      <AuthProvider>
+        {' '}
+        {/* AuthProvider might not be strictly necessary if RegisterPage doesn't use context directly, but good for consistency */}
         <RegisterPage />
       </AuthProvider>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 };
 
@@ -35,18 +37,25 @@ describe('RegisterPage', () => {
     // Default successful registration handler
     server.use(
       http.post('/api/auth/register', () => {
-        return HttpResponse.json({ message: 'User registered successfully' }, { status: 201 });
-      })
+        return HttpResponse.json(
+          { message: 'User registered successfully' },
+          { status: 201 },
+        );
+      }),
     );
   });
 
   it('renders registration form with username, email, password fields and a submit button', () => {
     renderRegisterPage();
-    expect(screen.getByRole('heading', { name: 'Register' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Register' }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText('Username:')).toBeInTheDocument();
     expect(screen.getByLabelText('Email:')).toBeInTheDocument();
     expect(screen.getByLabelText('Password:')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Register' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Register' }),
+    ).toBeInTheDocument();
   });
 
   it('allows user to type into form fields', async () => {
@@ -62,51 +71,63 @@ describe('RegisterPage', () => {
 
   it('submits form data and navigates to login on successful registration', async () => {
     renderRegisterPage();
-    
+
     await userEvent.type(screen.getByLabelText('Username:'), 'newuser');
     await userEvent.type(screen.getByLabelText('Email:'), 'new@example.com');
     await userEvent.type(screen.getByLabelText('Password:'), 'securepassword');
     await userEvent.click(screen.getByRole('button', { name: 'Register' }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/login', { state: { message: 'Registration successful! Please log in.' } });
+      expect(mockNavigate).toHaveBeenCalledWith('/login', {
+        state: { message: 'Registration successful! Please log in.' },
+      });
     });
   });
 
   it('displays error message on failed registration (e.g., email exists)', async () => {
     server.use(
       http.post('/api/auth/register', () => {
-        return HttpResponse.json({ message: 'Email already exists' }, { status: 409 });
-      })
+        return HttpResponse.json(
+          { message: 'Email already exists' },
+          { status: 409 },
+        );
+      }),
     );
     renderRegisterPage();
 
-    await userEvent.type(screen.getByLabelText('Email:'), 'existing@example.com');
+    await userEvent.type(
+      screen.getByLabelText('Email:'),
+      'existing@example.com',
+    );
     await userEvent.type(screen.getByLabelText('Password:'), 'password');
     await userEvent.click(screen.getByRole('button', { name: 'Register' }));
 
-    expect(await screen.findByText('Registration failed: Email already exists')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Registration failed: Email already exists'),
+    ).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('displays error message if API returns non-JSON error or network error', async () => {
     server.use(
       http.post('/api/auth/register', () => {
-        return new HttpResponse("Server Error", { status: 500 });
-      })
+        return new HttpResponse('Server Error', { status: 500 });
+      }),
     );
     renderRegisterPage();
 
     await userEvent.type(screen.getByLabelText('Email:'), 'test@example.com');
     await userEvent.type(screen.getByLabelText('Password:'), 'password');
     await userEvent.click(screen.getByRole('button', { name: 'Register' }));
-    
-    expect(await screen.findByText(/Registration failed:/)).toBeInTheDocument(); 
+
+    expect(await screen.findByText(/Registration failed:/)).toBeInTheDocument();
   });
 
   it('shows a link to the login page', () => {
     renderRegisterPage();
-    const loginLink = screen.getByRole('link', { name: 'Already have an account? Login' });
+    const loginLink = screen.getByRole('link', {
+      name: 'Already have an account? Login',
+    });
     expect(loginLink).toBeInTheDocument();
     expect(loginLink).toHaveAttribute('href', '/login');
   });

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -18,7 +18,7 @@ apiClient.interceptors.request.use(
   },
   (error) => {
     return Promise.reject(error);
-  }
+  },
 );
 
 // Optional: Add response interceptor for handling 401 errors globally

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -10,6 +10,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/setupTests.js',
     // Optional: if you want to see more details during test runs
-    // reporters: ['verbose'], 
+    // reporters: ['verbose'],
   },
-})
+});


### PR DESCRIPTION
This commit addresses two main issues highlighted by CI failures:

1. Backend Python linting (Flake8 E501):
    - Configured Flake8 to have a max line length of 88 characters and to ignore E203/W503 (for Black compatibility) by adding a `.flake8` file in the `backend/` directory.
    - Reformatted Python code in the `backend/` directory using `black .` to adhere to these standards.

2. Frontend npm script missing (format:check):
    - Added Prettier as a dev dependency to the `frontend/` project.
    - Created a `.prettierrc.json` file with standard formatting rules.
    - Added `format` ("prettier --write .") and `format:check` ("prettier --check .") scripts to `frontend/package.json`.
    - Reformatted frontend code using `npm run format`.

These changes should ensure that the CI pipeline passes both the Python linting/formatting checks and the frontend format check.