### PR TITLE
Fix: ESLint unused var in RegisterPage test and note on black formatting

### DIFF
--- a/frontend/src/pages/__tests__/RegisterPage.test.jsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.jsx
@@ -157,7 +157,7 @@ describe('RegisterPage', () => {
         }
         expect(diagnosticFlag).toBe(true);
       }, { timeout: 150 }); // Very short timeout for testing waitFor itself
-    } catch (e) {
+    } catch (_e) { // Changed e to _e
       // This catch block is expected to be hit if waitFor times out.
       // This is a "pass" for this part of the diagnostic.
       // If the test still times out at 400s, the problem is before this waitFor.


### PR DESCRIPTION
- Frontend:
  - `frontend/src/pages/__tests__/RegisterPage.test.jsx`: Fixed ESLint error `no-unused-vars` for variable `e` in a catch block by renaming it to `_e`.

- Backend:
  - Formatting with `black` for `backend/tests/test_tags_api.py` and `backend/app/api/routes.py` was skipped. The `black` formatter could not be installed in the environment due to persistent network/resource errors during `pip install black`. These files may still have formatting issues that `black` would correct.