### PR TITLE
Fix: Suppress ESLint no-unused-vars for _e and note black issue

### DIFF
--- a/frontend/src/pages/__tests__/RegisterPage.test.jsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.jsx
@@ -157,7 +157,8 @@ describe('RegisterPage', () => {
         }
         expect(diagnosticFlag).toBe(true);
       }, { timeout: 150 }); // Very short timeout for testing waitFor itself
-    } catch (_e) { // Changed e to _e
+    // eslint-disable-next-line no-unused-vars
+    } catch (_e) { 
       // This catch block is expected to be hit if waitFor times out.
       // This is a "pass" for this part of the diagnostic.
       // If the test still times out at 400s, the problem is before this waitFor.


### PR DESCRIPTION
- Frontend:
  - `frontend/src/pages/__tests__/RegisterPage.test.jsx`: I added an `// eslint-disable-next-line no-unused-vars` comment to suppress the 'no-unused-vars' error for the `_e` variable in a catch block. This is a workaround as the variable is intentionally unused.

- Backend:
  - The `black` formatting issues for Python files (`backend/tests/test_tags_api.py` and `backend/app/api/routes.py`) remain unresolved. I was unable to install the `black` tool in the execution environment due to persistent errors, preventing automated formatting. This will likely continue to cause CI failures if `black` checks are enforced.