### PR TITLE
Partial Fix: Address backend test errors/failures, attempt frontend t…

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -124,7 +124,7 @@ class Task(db.Model):
         "Comment", backref="task", lazy="dynamic", cascade="all, delete-orphan"
     )
     activity_logs = db.relationship(
-        "ActivityLog", backref="task", lazy="dynamic", cascade="all, delete-orphan"
+        "ActivityLog", backref="task", lazy="dynamic" # Cascade removed
     )
     tags = db.relationship(
         "Tag",

--- a/backend/app/services/activity_service.py
+++ b/backend/app/services/activity_service.py
@@ -30,7 +30,7 @@ def record_activity(
             task_id=task_id,
         )
         db.session.add(activity)
-        db.session.commit()  # Ensure this commit is intended or handled by a larger transaction
+        # db.session.commit() # Removed: Commit should be handled by the calling route/transaction
     except Exception as e:
         # TODO: Add more robust error handling/logging
         # (e.g., Sentry, specific logger)

--- a/backend/tests/test_projects_api.py
+++ b/backend/tests/test_projects_api.py
@@ -1,0 +1,217 @@
+import pytest
+from backend.app.models import Project
+
+# Fixtures like test_client, auth_headers, created_project_data, db_session,
+# and another_user_auth_headers_activity are assumed to be available from conftest.py
+
+def test_update_project_success_only_name(test_client, auth_headers, created_project_data, db_session):
+    project_id = created_project_data["id"]
+    new_name = "Updated Project Name Only"
+    headers = {"Authorization": auth_headers["Authorization"]}
+
+    # Fetch original description for assertion
+    get_response = test_client.get(f"/api/projects/{project_id}", headers=headers)
+    original_description = get_response.json["description"]
+
+    response = test_client.put(
+        f"/api/projects/{project_id}",
+        headers=headers,
+        json={"name": new_name}
+    )
+    assert response.status_code == 200
+    updated_project = response.json
+    assert updated_project["name"] == new_name
+    assert updated_project["description"] == original_description # Description should not change
+
+    # Verify in DB
+    project_db = db_session.query(Project).get(project_id)
+    assert project_db.name == new_name
+    assert project_db.description == original_description
+
+def test_update_project_success_only_description(test_client, auth_headers, created_project_data, db_session):
+    project_id = created_project_data["id"]
+    original_name = created_project_data["name"]
+    new_description = "Updated Project Description Only"
+    headers = {"Authorization": auth_headers["Authorization"]}
+
+    response = test_client.put(
+        f"/api/projects/{project_id}",
+        headers=headers,
+        json={"description": new_description}
+    )
+    assert response.status_code == 200
+    updated_project = response.json
+    assert updated_project["name"] == original_name # Name should not change
+    assert updated_project["description"] == new_description
+
+    # Verify in DB
+    project_db = db_session.query(Project).get(project_id)
+    assert project_db.name == original_name
+    assert project_db.description == new_description
+
+def test_update_project_empty_name_and_description(test_client, auth_headers, created_project_data, db_session):
+    project_id = created_project_data["id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+
+    # Fetch current project state
+    get_response = test_client.get(f"/api/projects/{project_id}", headers=headers)
+    original_name = get_response.json["name"] # Get current name
+    # original_description = get_response.json["description"] # Get current description
+
+    # Attempt to update with empty name string - should not change the name
+    response_empty_name = test_client.put(
+        f"/api/projects/{project_id}",
+        headers=headers,
+        json={"name": "   "} # Empty after strip
+    )
+    assert response_empty_name.status_code == 200
+    assert response_empty_name.json["name"] == original_name # Name should not change
+
+    # Verify in DB that name hasn't changed
+    project_db_after_empty_name = db_session.query(Project).get(project_id)
+    assert project_db_after_empty_name.name == original_name
+
+    # Attempt to update with empty description string - should change description to empty
+    response_empty_desc = test_client.put(
+        f"/api/projects/{project_id}",
+        headers=headers,
+        json={"description": "   "} # Empty after strip
+    )
+    assert response_empty_desc.status_code == 200
+    assert response_empty_desc.json["description"] == "" # Description should be empty
+    assert response_empty_desc.json["name"] == original_name # Name should remain original
+
+    # Verify in DB
+    project_db_after_empty_desc = db_session.query(Project).get(project_id)
+    assert project_db_after_empty_desc.description == ""
+    assert project_db_after_empty_desc.name == original_name
+
+
+def test_update_project_no_input_data(test_client, auth_headers, created_project_data):
+    project_id = created_project_data["id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    response = test_client.put(
+        f"/api/projects/{project_id}",
+        headers=headers,
+        json={} # No data
+    )
+    assert response.status_code == 400
+    assert response.json["message"] == "No input data provided"
+
+def test_update_project_forbidden(test_client, created_project_data, another_user_auth_headers_activity):
+    project_id = created_project_data["id"] # Created by the primary fixture user
+    other_user_headers = another_user_auth_headers_activity # Headers for a different user
+
+    response = test_client.put(
+        f"/api/projects/{project_id}",
+        headers=other_user_headers,
+        json={"name": "Attempt by Other User"}
+    )
+    assert response.status_code == 403
+    assert response.json["message"] == "Access forbidden"
+
+def test_update_non_existent_project(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
+    response = test_client.put(
+        "/api/projects/99999", # Non-existent ID
+        headers=headers,
+        json={"name": "Trying to update ghost project"}
+    )
+    assert response.status_code == 404
+    assert response.json["message"] == "Project not found"
+
+def test_update_project_success_name_and_description(test_client, auth_headers, created_project_data, db_session):
+    project_id = created_project_data["id"]
+    new_name = "Fully Updated Name"
+    new_description = "Fully Updated Description"
+    headers = {"Authorization": auth_headers["Authorization"]}
+
+    response = test_client.put(
+        f"/api/projects/{project_id}",
+        headers=headers,
+        json={"name": new_name, "description": new_description}
+    )
+    assert response.status_code == 200
+    updated_project = response.json
+    assert updated_project["name"] == new_name
+    assert updated_project["description"] == new_description
+
+    # Verify in DB
+    project_db = db_session.query(Project).get(project_id)
+    assert project_db.name == new_name
+    assert project_db.description == new_description
+
+def test_update_project_unauthorized(test_client, created_project_data):
+    project_id = created_project_data["id"]
+    # No Authorization header
+    response = test_client.put(
+        f"/api/projects/{project_id}",
+        json={"name": "Attempt without Auth"}
+    )
+    assert response.status_code == 401
+    # The specific message can vary, "Missing Authorization Header" is common for Flask-JWT-Extended
+    assert "Missing Authorization Header" in response.json.get("msg", "") or \
+           "Authorization Required" in response.json.get("message", "") # Adjust if message is different
+
+def test_create_project_missing_name(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
+    
+    # Test with no name field
+    response_no_name = test_client.post("/api/projects", headers=headers, json={"description": "Project without name"})
+    assert response_no_name.status_code == 400
+    assert response_no_name.json["message"] == "Project name is required"
+
+    # Test with empty name string
+    response_empty_name = test_client.post("/api/projects", headers=headers, json={"name": "   ", "description": "Project with empty name"})
+    assert response_empty_name.status_code == 400
+    assert response_empty_name.json["message"] == "Project name is required"
+
+    # Test with no data
+    response_no_data = test_client.post("/api/projects", headers=headers, json={})
+    assert response_no_data.status_code == 400
+    assert response_no_data.json["message"] == "Project name is required"
+
+def test_get_project_forbidden(test_client, created_project_data, another_user_auth_headers_activity):
+    project_id = created_project_data["id"] # Created by primary user
+    other_user_headers = another_user_auth_headers_activity
+
+    response = test_client.get(f"/api/projects/{project_id}", headers=other_user_headers)
+    assert response.status_code == 403
+    assert response.json["message"] == "Access forbidden" # Matches the message in get_project
+
+def test_get_non_existent_project(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
+    response = test_client.get("/api/projects/99999", headers=headers) # Non-existent ID
+    assert response.status_code == 404
+    assert response.json["message"] == "Project not found"
+
+# Test to ensure successful project creation is still fine (sanity check, good for coverage of success path)
+def test_create_project_success_with_description(test_client, auth_headers, db_session):
+    headers = {"Authorization": auth_headers["Authorization"]}
+    project_name = "Test Project with Desc"
+    project_desc = "A detailed description for this test project."
+    
+    response = test_client.post(
+        "/api/projects",
+        headers=headers,
+        json={"name": project_name, "description": project_desc}
+    )
+    assert response.status_code == 201
+    created_project = response.json
+    assert created_project["name"] == project_name
+    assert created_project["description"] == project_desc
+    assert "id" in created_project
+
+    # Verify in DB
+    project_db = db_session.query(Project).get(created_project["id"])
+    assert project_db is not None
+    assert project_db.name == project_name
+    assert project_db.description == project_desc
+    assert project_db.user_id == auth_headers["user_id"]
+
+    # Clean up: delete the created project to avoid interference if tests are not perfectly isolated by db_session commits/rollbacks
+    # This is generally good practice if not relying on full DB teardown/setup per test,
+    # but db_session fixture should handle rollback. However, explicit cleanup is safer.
+    # db_session.delete(project_db)
+    # db_session.commit()
+    # For now, rely on db_session fixture's rollback.

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -1,0 +1,196 @@
+import pytest
+from backend.app.models import Stage, Project
+
+# Fixtures: test_client, auth_headers, created_project_data, db_session,
+# another_user_auth_headers_activity (assuming it will be moved to conftest)
+
+# Helper to create a stage for tests that need an existing one
+@pytest.fixture(scope="function")
+def created_stage_data(test_client, auth_headers, created_project_data, db_session):
+    project_id = created_project_data["id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    stage_name = "Test Stage for Stages API"
+    
+    response = test_client.post(
+        f"/api/projects/{project_id}/stages",
+        headers=headers,
+        json={"name": stage_name, "order": 1}
+    )
+    if response.status_code != 201:
+        pytest.fail(f"Failed to create stage for setup: {response.json}")
+    stage_data = response.json
+    return {
+        "id": stage_data["id"],
+        "name": stage_data["name"],
+        "project_id": project_id,
+        "order": stage_data["order"]
+    }
+
+# === Tests for POST /api/projects/<project_id>/stages ===
+def test_create_stage_success(test_client, auth_headers, created_project_data, db_session):
+    project_id = created_project_data["id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    stage_name = "New Unique Stage"
+    stage_order = 10
+
+    response = test_client.post(
+        f"/api/projects/{project_id}/stages",
+        headers=headers,
+        json={"name": stage_name, "order": stage_order}
+    )
+    assert response.status_code == 201
+    created_stage = response.json
+    assert created_stage["name"] == stage_name
+    assert created_stage["order"] == stage_order
+    assert created_stage["project_id"] == project_id
+
+    stage_db = db_session.query(Stage).get(created_stage["id"])
+    assert stage_db is not None
+    assert stage_db.name == stage_name
+
+def test_create_stage_project_not_found(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
+    response = test_client.post(
+        "/api/projects/9999/stages",
+        headers=headers,
+        json={"name": "Stage for Ghost Project"}
+    )
+    assert response.status_code == 404
+    assert response.json["message"] == "Project not found"
+
+def test_create_stage_forbidden_for_project(test_client, created_project_data, another_user_auth_headers_activity):
+    project_id = created_project_data["id"] # Belongs to primary user
+    other_user_headers = another_user_auth_headers_activity
+
+    response = test_client.post(
+        f"/api/projects/{project_id}/stages",
+        headers=other_user_headers,
+        json={"name": "Stage by Other User"}
+    )
+    assert response.status_code == 403
+    assert response.json["message"] == "Access forbidden to this project"
+
+def test_create_stage_missing_name(test_client, auth_headers, created_project_data):
+    project_id = created_project_data["id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    
+    response = test_client.post(
+        f"/api/projects/{project_id}/stages",
+        headers=headers,
+        json={} # No name
+    )
+    assert response.status_code == 400
+    assert response.json["message"] == "Stage name is required"
+
+    response_empty_name = test_client.post(
+        f"/api/projects/{project_id}/stages",
+        headers=headers,
+        json={"name": "   "} # Empty name
+    )
+    assert response_empty_name.status_code == 400
+    assert response_empty_name.json["message"] == "Stage name is required"
+
+# === Tests for GET /api/projects/<project_id>/stages ===
+def test_get_stages_for_project_success(test_client, auth_headers, created_stage_data): # Uses created_stage_data
+    project_id = created_stage_data["project_id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+
+    response = test_client.get(f"/api/projects/{project_id}/stages", headers=headers)
+    assert response.status_code == 200
+    stages = response.json
+    assert isinstance(stages, list)
+    assert len(stages) >= 1 # At least the one created in created_stage_data
+    assert any(s["id"] == created_stage_data["id"] for s in stages)
+
+def test_get_stages_project_not_found(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
+    response = test_client.get("/api/projects/9999/stages", headers=headers)
+    assert response.status_code == 404
+    assert response.json["message"] == "Project not found"
+
+def test_get_stages_forbidden_for_project(test_client, created_project_data, another_user_auth_headers_activity):
+    project_id = created_project_data["id"]
+    other_user_headers = another_user_auth_headers_activity
+    response = test_client.get(f"/api/projects/{project_id}/stages", headers=other_user_headers)
+    assert response.status_code == 403
+    assert response.json["message"] == "Access forbidden to this project"
+
+# === Tests for PUT /api/stages/<stage_id> ===
+def test_update_stage_success(test_client, auth_headers, created_stage_data, db_session):
+    stage_id = created_stage_data["id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    new_name = "Updated Stage Name"
+    new_order = 5
+
+    response = test_client.put(
+        f"/api/stages/{stage_id}",
+        headers=headers,
+        json={"name": new_name, "order": new_order}
+    )
+    assert response.status_code == 200
+    updated_stage = response.json
+    assert updated_stage["name"] == new_name
+    assert updated_stage["order"] == new_order
+
+    stage_db = db_session.query(Stage).get(stage_id)
+    assert stage_db.name == new_name
+    assert stage_db.order == new_order
+
+def test_update_stage_not_found(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
+    response = test_client.put("/api/stages/9999", headers=headers, json={"name": "Ghost Stage"})
+    assert response.status_code == 404
+    assert response.json["message"] == "Stage not found"
+
+def test_update_stage_forbidden(test_client, created_stage_data, another_user_auth_headers_activity):
+    stage_id = created_stage_data["id"]
+    other_user_headers = another_user_auth_headers_activity
+    response = test_client.put(
+        f"/api/stages/{stage_id}",
+        headers=other_user_headers,
+        json={"name": "Update by Other"}
+    )
+    assert response.status_code == 403
+    assert response.json["message"] == "Access forbidden to this stage"
+
+def test_update_stage_no_input_data(test_client, auth_headers, created_stage_data):
+    stage_id = created_stage_data["id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    response = test_client.put(f"/api/stages/{stage_id}", headers=headers, json={})
+    assert response.status_code == 400
+    assert response.json["message"] == "No input data provided"
+
+def test_update_stage_empty_name(test_client, auth_headers, created_stage_data, db_session):
+    stage_id = created_stage_data["id"]
+    original_stage = db_session.query(Stage).get(stage_id)
+    original_name = original_stage.name
+    headers = {"Authorization": auth_headers["Authorization"]}
+
+    response = test_client.put(f"/api/stages/{stage_id}", headers=headers, json={"name": "   "})
+    assert response.status_code == 200 # Should not update if name is only whitespace
+    assert response.json["name"] == original_name
+
+
+# === Tests for DELETE /api/stages/<stage_id> ===
+def test_delete_stage_success(test_client, auth_headers, created_stage_data, db_session):
+    stage_id = created_stage_data["id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+
+    response = test_client.delete(f"/api/stages/{stage_id}", headers=headers)
+    assert response.status_code == 204
+    
+    stage_db = db_session.query(Stage).get(stage_id)
+    assert stage_db is None
+
+def test_delete_stage_not_found(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
+    response = test_client.delete("/api/stages/9999", headers=headers)
+    assert response.status_code == 404
+    assert response.json["message"] == "Stage not found"
+
+def test_delete_stage_forbidden(test_client, created_stage_data, another_user_auth_headers_activity):
+    stage_id = created_stage_data["id"]
+    other_user_headers = another_user_auth_headers_activity
+    response = test_client.delete(f"/api/stages/{stage_id}", headers=other_user_headers)
+    assert response.status_code == 403
+    assert response.json["message"] == "Access forbidden to this stage"

--- a/backend/tests/test_tags_api.py
+++ b/backend/tests/test_tags_api.py
@@ -52,8 +52,8 @@ def test_create_and_list_tags(test_client, auth_headers, db_session):
     assert found_tag2
 
 
-def test_create_tag_missing_name(test_client, auth_headers_tags):
-    headers = {"Authorization": auth_headers_tags["Authorization"]}
+def test_create_tag_missing_name(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
     # Test with an empty JSON payload, which might be caught by a global handler as 422
     response = test_client.post("/api/tags", headers=headers, json={})
     assert (
@@ -77,11 +77,11 @@ def test_create_tag_missing_name(test_client, auth_headers_tags):
 
 # POST /api/tasks/<task_id>/tags
 def test_add_tag_to_task_by_id_and_name(
-    test_client, auth_headers_tags, created_task_for_tags, db_session
+    test_client, auth_headers, created_task_data, db_session
 ):
-    headers = {"Authorization": auth_headers_tags["Authorization"]}
-    task_id = created_task_for_tags["task_id"]
-    project_id = created_task_for_tags["project_id"]  # For activity log check
+    headers = {"Authorization": auth_headers["Authorization"]}
+    task_id = created_task_data["task_id"]
+    project_id = created_task_data["project_id"]  # For activity log check
 
     # Create a tag first
     tag_name_existing = "ExistingTag"
@@ -151,10 +151,10 @@ def test_add_tag_to_task_by_id_and_name(
 
 
 def test_add_tag_to_task_invalid_input(
-    test_client, auth_headers_tags, created_task_for_tags
+    test_client, auth_headers, created_task_data
 ):
-    headers = {"Authorization": auth_headers_tags["Authorization"]}
-    task_id = created_task_for_tags["task_id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    task_id = created_task_data["task_id"]
 
     # No tag_id or tag_name - this might also be caught as 422 if payload is truly empty by a global handler
     response = test_client.post(f"/api/tasks/{task_id}/tags", headers=headers, json={})
@@ -174,8 +174,8 @@ def test_add_tag_to_task_invalid_input(
     assert "Tag with id 9999 not found" in response_bad_id.json["message"]
 
 
-def test_add_tag_to_non_existent_task(test_client, auth_headers_tags):
-    headers = {"Authorization": auth_headers_tags["Authorization"]}
+def test_add_tag_to_non_existent_task(test_client, auth_headers):
+    headers = {"Authorization": auth_headers["Authorization"]}
     response = test_client.post(
         "/api/tasks/8888/tags", headers=headers, json={"tag_name": "SomeTag"}
     )
@@ -195,11 +195,11 @@ def test_add_tag_to_task_unauthorized(
 
 # DELETE /api/tasks/<task_id>/tags/<tag_id>
 def test_remove_tag_from_task(
-    test_client, auth_headers_tags, created_task_for_tags, db_session
+    test_client, auth_headers, created_task_data, db_session
 ):
-    headers = {"Authorization": auth_headers_tags["Authorization"]}
-    task_id = created_task_for_tags["task_id"]
-    project_id = created_task_for_tags["project_id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    task_id = created_task_data["task_id"]
+    project_id = created_task_data["project_id"]
 
     # Add two tags first
     tag1_name = "TagToRemove1"
@@ -257,10 +257,10 @@ def test_remove_tag_from_task(
 
 
 def test_remove_tag_unauthorized_or_forbidden(
-    test_client, auth_headers_tags, created_task_for_tags
+    test_client, auth_headers, created_task_data
 ):
-    headers = {"Authorization": auth_headers_tags["Authorization"]}
-    task_id = created_task_for_tags["task_id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    task_id = created_task_data["task_id"]
     tag_to_add_res = test_client.post(
         "/api/tags", headers=headers, json={"name": "TempTagForDeleteTest"}
     )
@@ -294,10 +294,10 @@ def test_remove_tag_unauthorized_or_forbidden(
 
 # Test Task.to_dict() includes tags
 def test_task_to_dict_includes_tags(
-    test_client, auth_headers_tags, created_task_for_tags, db_session
+    test_client, auth_headers, created_task_data, db_session
 ):
-    headers = {"Authorization": auth_headers_tags["Authorization"]}
-    task_id = created_task_for_tags["task_id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    task_id = created_task_data["task_id"]
 
     # Add some tags
     tag_names = ["AlphaTag", "BetaTag"]
@@ -350,10 +350,10 @@ def test_task_to_dict_includes_tags(
 
 # Test adding tag by name where name is mixed case (should find existing if present, or create with given case)
 def test_add_tag_by_mixed_case_name(
-    test_client, auth_headers_tags, created_task_for_tags, db_session
+    test_client, auth_headers, created_task_data, db_session
 ):
-    headers = {"Authorization": auth_headers_tags["Authorization"]}
-    task_id = created_task_for_tags["task_id"]
+    headers = {"Authorization": auth_headers["Authorization"]}
+    task_id = created_task_data["task_id"]
 
     # 1. Create a tag with a specific casing
     original_tag_name = "MixedCaseTag"

--- a/frontend/src/pages/__tests__/RegisterPage.test.jsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.jsx
@@ -74,8 +74,11 @@ describe('RegisterPage', () => {
     const user = userEventLib.setup({ advanceTimers: vi.advanceTimersByTime }); // Use with fake timers
     renderRegisterPage();
     await user.type(screen.getByLabelText('Username'), 'newuser');
+    vi.runAllTimers();
     await user.type(screen.getByLabelText('Email'), 'new@example.com');
+    vi.runAllTimers();
     await user.type(screen.getByLabelText('Password'), 'securepassword');
+    vi.runAllTimers();
 
     expect(screen.getByLabelText('Username')).toHaveValue('newuser');
     expect(screen.getByLabelText('Email')).toHaveValue('new@example.com');
@@ -90,6 +93,7 @@ describe('RegisterPage', () => {
     await user.type(screen.getByLabelText('Email'), 'new@example.com');
     await user.type(screen.getByLabelText('Password'), 'securepassword');
     await user.click(screen.getByRole('button', { name: 'Register' }));
+    vi.runAllTimers();
 
     // Wait for the navigation to be called, accounting for the 2-second delay
     // Also, assert only with the arguments actually used by the component.
@@ -118,6 +122,7 @@ describe('RegisterPage', () => {
     await user.type(screen.getByLabelText('Email'), 'existing@example.com');
     await user.type(screen.getByLabelText('Password'), 'password');
     await user.click(screen.getByRole('button', { name: 'Register' }));
+    vi.runAllTimers(); // Added
     vi.runAllTimers(); // Try flushing all timers
 
     expect(
@@ -144,6 +149,7 @@ describe('RegisterPage', () => {
     await user.type(screen.getByLabelText('Email'), 'test@example.com');
     await user.type(screen.getByLabelText('Password'), 'password');
     await user.click(screen.getByRole('button', { name: 'Register' }));
+    vi.runAllTimers();
 
     // Diagnostic waitFor:
     let diagnosticFlag = false;


### PR DESCRIPTION
…imeout fix, and begin coverage improvement for routes.py

This commit includes several fixes and improvements based on recent CI failures:

Phase 1: Backend Test Fixes
- Corrected fixture names in `test_tags_api.py` (auth_headers_tags -> auth_headers, created_task_for_tags -> created_task_data) to resolve 9 test errors.
- Fixed `test_task_deletion_logs_activity` in `test_activity_log_api.py`:
    - Removed `cascade="all, delete-orphan"` from `Task.activity_logs` relationship in `models.py` to prevent deletion of activity logs when a task is deleted.
    - Removed `db.session.commit()` from `activity_service.record_activity` to allow routes to manage the transaction unit-of-work.

Phase 2: Frontend Test Timeout Fix Attempt
- Added `vi.runAllTimers()` after `userEvent` calls in `frontend/src/pages/__tests__/RegisterPage.test.jsx` for 4 tests that were timing out. This is an attempt to ensure proper timer flushing.

Phase 3: Backend Coverage Improvement (routes.py - In Progress)
- Began addressing low coverage in `backend/app/api/routes.py`.
- Created `backend/tests/test_projects_api.py` with new tests for `create_project` and `update_project` endpoints, covering various success and error scenarios.
- Created `backend/tests/test_stages_api.py` with new tests for stage CRUD operations (create, get, update, delete), covering various success and error scenarios.

Next steps in the ongoing plan were to refactor a shared fixture (`another_user_auth_headers_activity`) to `conftest.py`, continue adding tests for tasks and other uncovered API routes, then improve model and service coverage, and finally run all checks.